### PR TITLE
Implement dev setup scripts and docs

### DIFF
--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -1,6 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure required versions are available
+PY_VER=$(python3 --version 2>/dev/null || true)
+if [[ $PY_VER != 3.11* ]]; then
+  echo "Warning: Python 3.11 is recommended. Found: $PY_VER" >&2
+fi
+
+NODE_VER=$(node --version 2>/dev/null || true)
+if [[ -z $NODE_VER ]]; then
+  echo "Node.js is required but not found" >&2
+  exit 1
+fi
+NODE_MAJOR=${NODE_VER#v}
+NODE_MAJOR=${NODE_MAJOR%%.*}
+if (( NODE_MAJOR < 18 )); then
+  echo "Warning: Node.js 18+ is recommended. Found: $NODE_VER" >&2
+fi
+
 echo "Installing Python dependencies..."
 pip install -r backend/requirements.txt
 

--- a/.project-management/current-prd/tasks-prd-project-initialization.md
+++ b/.project-management/current-prd/tasks-prd-project-initialization.md
@@ -78,6 +78,10 @@
 - `frontend/src/components/HealthCheckDisplay.tsx` - Displays backend health status.
 - `frontend/eslint.config.js` - Updated ESLint rules for TypeScript.
 - `frontend/.prettierrc` - Prettier configuration.
+- `dev_init.sh` - Script to set up environment and start both servers.
+- `.codex/install.sh` - Ensures required versions and installs dependencies.
+- `README.md` - Added development setup instructions.
+- `DEVELOPMENT.md` - Documented manual startup commands.
 
 ### Notes
 
@@ -103,7 +107,7 @@
 
 ## Tasks
 
-- [ ] 1.0 Initialize Frontend Project (Vite + React + TypeScript). This task is informed by the design mock-up found at `/Users/kevinsullivan/code/shiny-broccoli/.project-management/current-prd/prd-background/design-mock.html`.
+- [x] 1.0 Initialize Frontend Project (Vite + React + TypeScript). This task is informed by the design mock-up found at `/Users/kevinsullivan/code/shiny-broccoli/.project-management/current-prd/prd-background/design-mock.html`.
   - [x] 1.1 Set up a new Vite project with the React TypeScript template in the `frontend` directory.
   - [x] 1.2 Install necessary dependencies: `react-router-dom`, `axios` (or preferred HTTP client).
   - [x] 1.3 Configure ESLint and Prettier for code quality and consistency (e.g., create/update `frontend/.eslintrc.cjs`, `frontend/.prettierrc`). Ensure TypeScript linting rules are active.
@@ -112,7 +116,7 @@
   - [x] 1.6 Create a simple `HomePage.tsx` component in `frontend/src/pages/`.
   - [x] 1.7 Configure Vite (`frontend/vite.config.ts`) to run the dev server on port 5173 and ensure hot reloading is functional.
   - [x] 1.8 Create a basic `App.test.tsx` to ensure the testing framework (Vitest or Jest) is configured and working.
-- [ ] 2.0 Initialize Backend Project (FastAPI + Python 3.11)
+- [x] 2.0 Initialize Backend Project (FastAPI + Python 3.11)
   - [x] 2.1 Create a `backend/app` directory for the FastAPI application.
   - [x] 2.2 Initialize a `backend/requirements.txt` file with `fastapi`, `uvicorn[standard]`, `python-dotenv`, `pytest`, `httpx`.
   - [x] 2.3 Create `backend/app/main.py` to initialize the FastAPI app.
@@ -121,31 +125,31 @@
   - [x] 2.6 Register the health endpoint router in `backend/app/main.py`.
   - [x] 2.7 Configure Uvicorn to run the FastAPI app on port 8000 with auto-reload for development (e.g., via a script in `package.json` or a helper script).
   - [x] 2.8 Create basic test setup in `backend/tests/` (e.g. `backend/tests/conftest.py`) and a test for the health endpoint in `backend/tests/api/v1/test_health.py`.
-- [ ] 3.0 Configure Project Environment and Core Setup 
+- [x] 3.0 Configure Project Environment and Core Setup
   - [x] 3.1 Create a root `.gitignore` file, ensuring it covers `node_modules`, Python `__pycache__`, virtual environments (`.venv`, `venv`), `.env` files, OS-specific files (e.g., `.DS_Store`), and build artifacts.
   - [x] 3.2 Create `backend/.env.example` with a placeholder for `OPENAI_API_KEY=""`.
   - [x] 3.3 Implement environment variable loading in `backend/app/core/config.py` using Pydantic Settings to read from `.env`.
   - [x] 3.4 Ensure Vite frontend correctly handles environment variables (e.g., `VITE_API_BASE_URL`) via `.env` files in the `frontend` directory. Create `frontend/.env.example` if needed.
-- [ ] 4.0 Establish Basic Full-Stack Connectivity & Verification
+- [x] 4.0 Establish Basic Full-Stack Connectivity & Verification
   - [x] 4.1 Create `frontend/src/services/apiClient.ts` to handle API calls to the backend (e.g., using Axios, configured with `VITE_API_BASE_URL=http://localhost:8000/api/v1`).
   - [x] 4.2 Create `frontend/src/components/HealthCheckDisplay.tsx` that calls the backend's `/health` endpoint via `apiClient.ts` and displays the status.
   - [x] 4.3 Add the `HealthCheckDisplay` component to `HomePage.tsx`.
   - [x] 4.4 Verify that the frontend successfully calls the backend and displays the health status.
 - [ ] 5.0 Finalize Development Tooling, Scripts, and Documentation
-  - [ ] 5.1 Create/Update `dev_init.sh` script in the root directory to:
-    - [ ] 5.1.1 Check for Python 3.11 and Node LTS.
-    - [ ] 5.1.2 Set up Python virtual environment in `backend/.venv` and install `requirements.txt`.
-    - [ ] 5.1.3 Install frontend dependencies (`npm install` in `frontend`).
-    - [ ] 5.1.4 Copy `.env.example` to `.env` in `backend` if `.env` doesn't exist.
-    - [ ] 5.1.5 Launch both backend (Uvicorn from `backend` dir) and frontend (Vite dev server from `frontend` dir) services, potentially using a concurrent runner or clear instructions for separate terminals.
-  - [ ] 5.2 Update/Create `.codex/install.sh` to ensure Python 3.11 and Node LTS are available in the agent's environment.
-  - [ ] 5.3 Create/Update the root `README.md` with:
-    - [ ] 5.3.1 Project overview.
-    - [ ] 5.3.2 Detailed prerequisites (Python 3.11, Node LTS, pip, npm/yarn).
-    - [ ] 5.3.3 Step-by-step setup instructions using `dev_init.sh`.
-    - [ ] 5.3.4 Instructions on how to run the frontend and backend separately if needed.
-    - [ ] 5.3.5 Information on environment variable setup (`.env` files).
-    - [ ] 5.3.6 Basic troubleshooting tips.
-  - [ ] 5.4 Ensure all initial code files pass linting checks.
+- [x] 5.1 Create/Update `dev_init.sh` script in the root directory to:
+    - [x] 5.1.1 Check for Python 3.11 and Node LTS.
+    - [x] 5.1.2 Set up Python virtual environment in `backend/.venv` and install `requirements.txt`.
+    - [x] 5.1.3 Install frontend dependencies (`npm install` in `frontend`).
+    - [x] 5.1.4 Copy `.env.example` to `.env` in `backend` if `.env` doesn't exist.
+    - [x] 5.1.5 Launch both backend (Uvicorn from `backend` dir) and frontend (Vite dev server from `frontend` dir) services, potentially using a concurrent runner or clear instructions for separate terminals.
+- [x] 5.2 Update/Create `.codex/install.sh` to ensure Python 3.11 and Node LTS are available in the agent's environment.
+- [x] 5.3 Create/Update the root `README.md` with:
+    - [x] 5.3.1 Project overview.
+    - [x] 5.3.2 Detailed prerequisites (Python 3.11, Node LTS, pip, npm/yarn).
+    - [x] 5.3.3 Step-by-step setup instructions using `dev_init.sh`.
+    - [x] 5.3.4 Instructions on how to run the frontend and backend separately if needed.
+    - [x] 5.3.5 Information on environment variable setup (`.env` files).
+    - [x] 5.3.6 Basic troubleshooting tips.
+- [x] 5.4 Ensure all initial code files pass linting checks.
   - [ ] 5.5 Manually verify all success metrics from the PRD (SM1-SM6) are met.
 *End of document*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 2025-06-13 Initialized backend structure with health endpoint and basic tests
 2025-06-13 Added dev server script and frontend environment config
 2025-06-13 Implemented initial frontend routing and health check component
+2025-06-13 Added dev_init.sh and updated install script and README

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,11 +1,24 @@
-### Notes on local development setup.  
+### Notes on local development setup.
 
 ## Local Development
-This section describes development environment setup and is maintained by the codex agent
-
+This section describes development environment setup and is maintained by the codex agent.
 
 ### Frontend
-
+Run `npm install` inside `frontend` to install dependencies. Start the dev server with `npm run dev`.
 
 ### Backend
+Create a virtual environment in `backend/.venv` and install requirements:
 
+```bash
+python3 -m venv backend/.venv
+source backend/.venv/bin/activate
+pip install -r backend/requirements.txt
+```
+
+Start the server using Uvicorn:
+
+```bash
+uvicorn backend.app.main:app --reload --port 8000
+```
+
+Alternatively run the combined `dev_init.sh` script from the repository root to automate these steps.

--- a/README.md
+++ b/README.md
@@ -96,3 +96,40 @@ Starting with any description of a feature, this project supplies tooling to aut
 ## Codex Environment Setup
 Go to https://chatgpt.com/codex/settings/environments, select or create your github-connected environment then Edit -> Advanced and copy-paste install.sh into the startup script textbox. Save
 *End of document*
+
+## Development Setup
+
+### Prerequisites
+- Python 3.11
+- Node.js 18 or 20
+- `pip` and `npm` available on your path
+
+### Quick Start
+Run the helper script which installs dependencies and starts both servers:
+
+```bash
+./dev_init.sh
+```
+
+The backend will start on http://localhost:8000 and the frontend on http://localhost:5173.
+
+### Running Services Separately
+If you prefer separate terminals:
+
+```bash
+# Backend
+cd backend && source .venv/bin/activate && uvicorn backend.app.main:app --reload
+
+# Frontend
+cd frontend && npm run dev
+```
+
+### Environment Variables
+Backend settings are loaded from `backend/.env`. Create this from
+`backend/.env.example` and supply your values. Frontend variables use Vite's
+`.env` files (see `frontend/.env.example`).
+
+### Troubleshooting
+- Ensure required versions of Python and Node are installed if the script exits.
+- Delete `backend/.venv` or `frontend/node_modules` to force a clean install if
+  you encounter dependency issues.

--- a/dev_init.sh
+++ b/dev_init.sh
@@ -1,33 +1,57 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# NOTE TO Codex agent: If you are reading this, it means you are bootstraping a new project.
-# It is your responsibility to fill in the missing parts of this script, the headings below
-# are just a guide to help you with common development application startup tasks.
-# Remove these comments and complete the script as needed.
+# Development initialization script
+# Checks prerequisites, installs dependencies, and starts both backend and frontend.
 
+# --------- Helper Functions ---------
+require_python() {
+  local ver
+  if ! ver=$(python3 --version 2>/dev/null); then
+    echo "Python 3.11+ is required but not found" >&2
+    exit 1
+  fi
+  ver=${ver#Python }
+  if [[ $ver != 3.11* && $ver != 3.12* ]]; then
+    echo "Warning: expected Python 3.11.x, found $ver" >&2
+  fi
+}
 
+require_node() {
+  local ver
+  if ! ver=$(node --version 2>/dev/null); then
+    echo "Node.js 18+ is required but not found" >&2
+    exit 1
+  fi
+  ver=${ver#v}
+  major=${ver%%.*}
+  if (( major < 18 )); then
+    echo "Warning: expected Node.js 18+ (or 20), found $ver" >&2
+  fi
+}
 
-# Export optional debug environment variables if provided
+# --------- Checks ---------
+require_python
+require_node
 
-# Example CORS allowed origins for the backend (comma-separated)
-#: "${ALLOW_ORIGINS:=http://localhost:5173}"
-#export ALLOW_ORIGINS
+# --------- Backend Setup ---------
+if [ ! -d backend/.venv ]; then
+  python3 -m venv backend/.venv
+fi
+source backend/.venv/bin/activate
+pip install -r backend/requirements.txt
+if [ ! -f backend/.env ]; then
+  cp backend/.env.example backend/.env
+fi
 
-# Kill existing processes
+# --------- Frontend Setup ---------
+(cd frontend && npm install)
 
-# Create virtual environment if it doesn't exist
+# --------- Start Servers ---------
+uvicorn backend.app.main:app --reload --port 8000 &
+BACKEND_PID=$!
+(cd frontend && npm run dev) &
+FRONTEND_PID=$!
 
-# Activate virtual environment
-
-# Install  dependencies
-
-# Start backend in background
-
-# Start frontend in background
-
-# Wait briefly for servers to start
-
-# Open in default browser (macOS or Linux)
-
-#  Wait for servers to shut down manually
+trap 'kill $BACKEND_PID $FRONTEND_PID' INT TERM
+wait $FRONTEND_PID


### PR DESCRIPTION
## Summary
- add dev_init.sh for combined backend/frontend setup
- check tool versions in .codex/install.sh
- document startup steps in README and DEVELOPMENT
- update task list statuses
- note changes in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_684bc6ed24508331947c155527a8d3a6