### PR TITLE
Implement image upload endpoints

### DIFF
--- a/.project-management/current-prd/tasks-prd-foundation-epic.md
+++ b/.project-management/current-prd/tasks-prd-foundation-epic.md
@@ -66,6 +66,7 @@
 - `backend/tests/api/v1/test_images.py` - Unit tests for the image endpoints.
 
 ### Existing Files Modified
+- `.project-management/current-prd/tasks-prd-foundation-epic.md` - Task tracking updates.
 - `frontend/src/pages/HomePage.tsx` - To integrate the new `FileUpload` and `CanvasDisplay` components.
 - `frontend/src/services/apiClient.ts` - To add functions for interacting with the new image endpoints.
 - `backend/app/main.py` - To include the new image router.
@@ -98,15 +99,15 @@
   - [ ] 2.8 Style the canvas and drawing controls area according to the design mock.
   - [ ] 2.9 Write unit tests for `CanvasDisplay.tsx` and `useCanvas.ts`.
 - [ ] 3.0 Create Backend API Endpoints for Image Handling (FR10-FR14, US4).
-  - [ ] 3.1 Create `backend/app/api/v1/endpoints/images.py`.
-  - [ ] 3.2 Implement `POST /api/v1/images/upload` endpoint to receive multipart form data (image). (Ref: FR10, API Specs)
-  - [ ] 3.3 Add backend validation for image file type and security. (Ref: FR11)
-  - [ ] 3.4 Implement `POST /api/v1/images/process` endpoint to receive image and mask data (stubbed response). (Ref: FR10, API Specs)
-  - [ ] 3.5 Return structured JSON responses for success and error cases for both endpoints. (Ref: FR12, API Specs)
-  - [ ] 3.6 Implement logging for incoming requests and processing times. (Ref: FR14)
-  - [ ] 3.7 Add the new `images` router to `backend/app/main.py`.
-  - [ ] 3.8 Create `backend/services/image_processor.py` with stubbed processing logic.
-  - [ ] 3.9 Write unit tests for the image API endpoints in `backend/tests/api/v1/test_images.py`.
+  - [x] 3.1 Create `backend/app/api/v1/endpoints/images.py`.
+  - [x] 3.2 Implement `POST /api/v1/images/upload` endpoint to receive multipart form data (image). (Ref: FR10, API Specs)
+  - [x] 3.3 Add backend validation for image file type and security. (Ref: FR11)
+  - [x] 3.4 Implement `POST /api/v1/images/process` endpoint to receive image and mask data (stubbed response). (Ref: FR10, API Specs)
+  - [x] 3.5 Return structured JSON responses for success and error cases for both endpoints. (Ref: FR12, API Specs)
+  - [x] 3.6 Implement logging for incoming requests and processing times. (Ref: FR14)
+  - [x] 3.7 Add the new `images` router to `backend/app/main.py`.
+  - [x] 3.8 Create `backend/services/image_processor.py` with stubbed processing logic.
+  - [x] 3.9 Write unit tests for the image API endpoints in `backend/tests/api/v1/test_images.py`.
 - [ ] 4.0 Integrate Frontend with Backend for Image Workflow (FR15-FR17, US4).
   - [ ] 4.1 Update `frontend/src/services/apiClient.ts` to include functions for `/api/v1/images/upload` and `/api/v1/images/process`.
   - [ ] 4.2 Connect `FileUpload.tsx` to call the `/api/v1/images/upload` endpoint. (Ref: FR15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 2025-06-13 Added dev server script and frontend environment config
 2025-06-13 Implemented initial frontend routing and health check component
 2025-06-13 Added dev_init.sh and updated install script and README
+2025-06-13 Added image upload endpoints and tests

--- a/backend/app/api/v1/endpoints/images.py
+++ b/backend/app/api/v1/endpoints/images.py
@@ -1,0 +1,47 @@
+import logging
+import time
+from fastapi import APIRouter, UploadFile, File, HTTPException, status
+
+from backend.services.image_processor import process_image
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+}
+
+router = APIRouter()
+
+
+def _validate_file(file: UploadFile) -> None:
+    if file.content_type not in ALLOWED_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported file type",
+        )
+
+
+@router.post("/images/upload")
+async def upload_image(file: UploadFile = File(...)):
+    start = time.time()
+    logger.info("/images/upload called")
+    _validate_file(file)
+    # Stubbed processing: just acknowledge receipt
+    result = {"filename": file.filename}
+    logger.info("/images/upload completed in %.3f", time.time() - start)
+    return result
+
+
+@router.post("/images/process")
+async def process_endpoint(
+    file: UploadFile = File(...), mask: UploadFile | None = File(None)
+):
+    start = time.time()
+    logger.info("/images/process called")
+    _validate_file(file)
+    result = await process_image(file, mask)
+    logger.info("/images/process completed in %.3f", time.time() - start)
+    return result

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .core.config import get_settings
 from .api.v1.endpoints.health import router as health_router
+from .api.v1.endpoints.images import router as images_router
 
 settings = get_settings()
 
@@ -17,6 +18,7 @@ app.add_middleware(
 )
 
 app.include_router(health_router, prefix="/api/v1")
+app.include_router(images_router, prefix="/api/v1")
 
 
 @app.get("/")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ pydantic-settings
 pytest
 flake8
 httpx
+python-multipart

--- a/backend/services/image_processor.py
+++ b/backend/services/image_processor.py
@@ -1,0 +1,9 @@
+"""Image processing service stubs."""
+
+from fastapi import UploadFile
+
+
+async def process_image(file: UploadFile, mask: UploadFile | None) -> dict:
+    """Stub image processing function."""
+    # Real implementation would process the image and mask.
+    return {"detail": "processing not implemented"}

--- a/backend/tests/api/v1/test_images.py
+++ b/backend/tests/api/v1/test_images.py
@@ -1,0 +1,30 @@
+import io
+
+
+def test_upload_image(client):
+    file_content = io.BytesIO(b"data")
+    response = client.post(
+        "/api/v1/images/upload",
+        files={"file": ("test.png", file_content, "image/png")},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"filename": "test.png"}
+
+
+def test_upload_invalid_type(client):
+    file_content = io.BytesIO(b"data")
+    response = client.post(
+        "/api/v1/images/upload",
+        files={"file": ("test.txt", file_content, "text/plain")},
+    )
+    assert response.status_code == 400
+
+
+def test_process_image(client):
+    file_content = io.BytesIO(b"data")
+    response = client.post(
+        "/api/v1/images/process",
+        files={"file": ("test.png", file_content, "image/png")},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"detail": "processing not implemented"}


### PR DESCRIPTION
## Summary
- add endpoints for image upload and processing
- stub out image processing service
- register new router and tests
- document new dependency
- update tasks for progress

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh` *(fails: RuntimeError: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_684bcdfdf7908331bda5d85535ecc555