### PR TITLE
Implement CanvasDisplay integration

### DIFF
--- a/.project-management/current-prd/tasks-prd-foundation-epic.md
+++ b/.project-management/current-prd/tasks-prd-foundation-epic.md
@@ -115,7 +115,7 @@
   - [x] 4.2 Connect `FileUpload.tsx` to call the `/api/v1/images/upload` endpoint. (Ref: FR15)
   - [ ] 4.3 Implement a "Submit" button/workflow in the frontend that sends the original image and mask data (from `CanvasDisplay.tsx`) to the `/api/v1/images/process` endpoint. (Ref: FR17)
   - [ ] 4.4 Handle API responses, including network errors and timeouts, displaying user-friendly messages. (Ref: FR16)
-  - [c] 4.5 Integrate `FileUpload.tsx` and `CanvasDisplay.tsx` into `frontend/src/pages/HomePage.tsx`.
+  - [x] 4.5 Integrate `FileUpload.tsx` and `CanvasDisplay.tsx` into `frontend/src/pages/HomePage.tsx`.
 - [ ] 5.0 Ensure Project Structure and Documentation for Phase 1 Completion (G5, G6, SM1-SM7).
   - [ ] 5.1 Review and update `dev_init.sh` if any new backend/frontend dependencies or setup steps were added.
   - [ ] 5.2 Update `frontend/package.json` and `backend/requirements.txt` with any new dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 2025-06-13 Added image upload endpoints and tests
 2025-06-13 Added API client functions for image upload and processing
 2025-06-13 Added FileUpload component with validation and tests
+2025-06-13 Added CanvasDisplay component and integrated into HomePage

--- a/frontend/src/components/CanvasDisplay.tsx
+++ b/frontend/src/components/CanvasDisplay.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+
+export default function CanvasDisplay({ image }: { image: File | null }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !image) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const img = new Image();
+    img.onload = () => {
+      canvas.width = img.width;
+      canvas.height = img.height;
+      ctx.drawImage(img, 0, 0);
+    };
+    img.src = URL.createObjectURL(image);
+    return () => {
+      URL.revokeObjectURL(img.src);
+    };
+  }, [image]);
+
+  return (
+    <div className="border rounded p-4 mt-4">
+      {image ? (
+        <canvas ref={canvasRef} className="border" />
+      ) : (
+        <div>No image uploaded yet.</div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,14 +1,18 @@
+import { useState } from 'react';
 import HealthCheckDisplay from '../components/HealthCheckDisplay';
 import FileUpload from '../components/FileUpload';
+import CanvasDisplay from '../components/CanvasDisplay';
 
 export default function HomePage() {
+  const [image, setImage] = useState<File | null>(null);
   return (
     <div>
       <h1>Welcome to Shiny Broccoli</h1>
       <HealthCheckDisplay />
       <div className="my-4">
-        <FileUpload />
+        <FileUpload onUploaded={setImage} />
       </div>
+      <CanvasDisplay image={image} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `CanvasDisplay` component
- integrate `FileUpload` with `CanvasDisplay` on the Home page
- mark the integration task complete
- update changelog

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_684bd2516460833193b811ace26ac4be