### PR TITLE
Implement mask layer and submit workflow

### DIFF
--- a/.project-management/current-prd/tasks-prd-foundation-epic.md
+++ b/.project-management/current-prd/tasks-prd-foundation-epic.md
@@ -61,7 +61,9 @@
 - `frontend/src/components/FileUpload.tsx` - Component for handling file uploads.
 - `frontend/src/components/FileUpload.test.tsx` - Unit tests for `FileUpload` component.
 - `frontend/src/components/CanvasDisplay.tsx` - Component for displaying the image and handling drawing.
+- `frontend/src/components/CanvasDisplay.test.tsx` - Unit tests for `CanvasDisplay` component.
 - `frontend/src/hooks/useCanvas.ts` - Hook for managing canvas state and drawing logic.
+- `frontend/src/hooks/useCanvas.test.tsx` - Unit tests for `useCanvas` hook.
 - `backend/app/api/v1/endpoints/images.py` - API endpoints for image upload and processing.
 - `backend/services/image_processor.py` - Service for handling image processing logic (stubbed for now).
 - `backend/tests/api/v1/test_images.py` - Unit tests for the image endpoints.
@@ -97,16 +99,16 @@
   - [x] 1.4 On successful upload, pass the image data to the canvas component. (Ref: FR4)
   - [x] 1.5 Style the file upload area according to the design mock.
   - [x] 1.6 Write unit tests for `FileUpload.tsx`.
-- [ ] 2.0 Develop Canvas Interface for Image Display and Basic Mask Drawing (FR5-FR9, US2, US3, US5). This task is informed by `/Users/kevinsullivan/code/shiny-broccoli/.project-management/closed-prd/prd-background/design-mock.html`.
+ - [x] 2.0 Develop Canvas Interface for Image Display and Basic Mask Drawing (FR5-FR9, US2, US3, US5). This task is informed by `/Users/kevinsullivan/code/shiny-broccoli/.project-management/closed-prd/prd-background/design-mock.html`.
   - [x] 2.1 Create `CanvasDisplay.tsx` component that receives an image and renders it on an HTML5 canvas. (Ref: FR5)
   - [x] 2.2 Implement proper image scaling to fit the canvas while maintaining aspect ratio. (Ref: FR5, Technical Considerations)
   - [x] 2.3 Implement a basic brush/pen tool for drawing on the canvas. (Ref: FR6)
   - [x] 2.4 Add functionality to toggle between drawing and erasing modes. (Ref: FR7)
   - [x] 2.5 Provide visual feedback during drawing (e.g., cursor change, stroke preview). (Ref: FR8)
-  - [ ] 2.6 Ensure the drawn mask is a separate layer that can be toggled for visibility. (Ref: FR9)
+  - [x] 2.6 Ensure the drawn mask is a separate layer that can be toggled for visibility. (Ref: FR9)
   - [x] 2.7 Create `useCanvas.ts` hook to manage canvas state, drawing logic (brush, eraser), and mask data.
   - [x] 2.8 Style the canvas and drawing controls area according to the design mock.
-  - [ ] 2.9 Write unit tests for `CanvasDisplay.tsx` and `useCanvas.ts`.
+  - [x] 2.9 Write unit tests for `CanvasDisplay.tsx` and `useCanvas.ts`.
 - [x] 3.0 Create Backend API Endpoints for Image Handling (FR10-FR14, US4).
   - [x] 3.1 Create `backend/app/api/v1/endpoints/images.py`.
   - [x] 3.2 Implement `POST /api/v1/images/upload` endpoint to receive multipart form data (image). (Ref: FR10, API Specs)
@@ -117,11 +119,11 @@
   - [x] 3.7 Add the new `images` router to `backend/app/main.py`.
   - [x] 3.8 Create `backend/services/image_processor.py` with stubbed processing logic.
   - [x] 3.9 Write unit tests for the image API endpoints in `backend/tests/api/v1/test_images.py`.
-- [ ] 4.0 Integrate Frontend with Backend for Image Workflow (FR15-FR17, US4).
+- [x] 4.0 Integrate Frontend with Backend for Image Workflow (FR15-FR17, US4).
   - [x] 4.1 Update `frontend/src/services/apiClient.ts` to include functions for `/api/v1/images/upload` and `/api/v1/images/process`.
   - [x] 4.2 Connect `FileUpload.tsx` to call the `/api/v1/images/upload` endpoint. (Ref: FR15)
-  - [ ] 4.3 Implement a "Submit" button/workflow in the frontend that sends the original image and mask data (from `CanvasDisplay.tsx`) to the `/api/v1/images/process` endpoint. (Ref: FR17)
-  - [ ] 4.4 Handle API responses, including network errors and timeouts, displaying user-friendly messages. (Ref: FR16)
+  - [x] 4.3 Implement a "Submit" button/workflow in the frontend that sends the original image and mask data (from `CanvasDisplay.tsx`) to the `/api/v1/images/process` endpoint. (Ref: FR17)
+  - [x] 4.4 Handle API responses, including network errors and timeouts, displaying user-friendly messages. (Ref: FR16)
   - [x] 4.5 Integrate `FileUpload.tsx` and `CanvasDisplay.tsx` into `frontend/src/pages/HomePage.tsx`.
 - [ ] 5.0 Ensure Project Structure and Documentation for Phase 1 Completion (G5, G6, SM1-SM7).
   - [ ] 5.1 Review and update `dev_init.sh` if any new backend/frontend dependencies or setup steps were added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 2025-06-13 Implemented canvas image scaling
 2025-06-13 Added drawing hook and basic brush functionality
 2025-06-13 Added erase mode toggle and canvas styling
+2025-06-13 Added mask layer toggle, submit workflow, and canvas tests

--- a/frontend/src/components/CanvasDisplay.test.tsx
+++ b/frontend/src/components/CanvasDisplay.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import CanvasDisplay from './CanvasDisplay';
+
+vi.stubGlobal('Image', class {
+  onload: (() => void) | null = null;
+  width = 100;
+  height = 100;
+  set src(_val: string) {
+    this.onload && this.onload();
+  }
+});
+
+HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+  clearRect: vi.fn(),
+  drawImage: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  stroke: vi.fn(),
+} as unknown as CanvasRenderingContext2D));
+
+HTMLCanvasElement.prototype.toBlob = vi.fn(function (cb) {
+  cb?.(new Blob());
+});
+
+vi.mock('../services/apiClient', () => ({
+  processImage: vi.fn(() => Promise.resolve({ detail: 'ok' })),
+}));
+
+global.URL.createObjectURL = vi.fn(() => 'blob:url');
+global.URL.revokeObjectURL = vi.fn();
+
+describe('CanvasDisplay', () => {
+  it('toggles mask visibility and submits', async () => {
+    const file = new File(['data'], 'test.png', { type: 'image/png' });
+    const { getByText } = render(<CanvasDisplay image={file} />);
+    await waitFor(() => getByText('Switch to Erase'));
+    const toggle = getByText('Hide Mask');
+    fireEvent.click(toggle);
+    expect(toggle.textContent).toBe('Show Mask');
+    fireEvent.click(getByText('Submit'));
+    await waitFor(() => getByText('ok'));
+  });
+});

--- a/frontend/src/components/CanvasDisplay.tsx
+++ b/frontend/src/components/CanvasDisplay.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import useCanvas from '../hooks/useCanvas';
+import { processImage } from '../services/apiClient';
 
 /**
  * Displays an uploaded image on an HTML5 canvas.
@@ -8,11 +9,18 @@ import useCanvas from '../hooks/useCanvas';
  */
 
 export default function CanvasDisplay({ image }: { image: File | null }) {
-  const { canvasRef, mode, toggleMode } = useCanvas();
+  const baseRef = useRef<HTMLCanvasElement>(null);
+  const { canvasRef: maskRef, mode, toggleMode } = useCanvas();
+  const [maskVisible, setMaskVisible] = useState(true);
+  const [submitMsg, setSubmitMsg] = useState('');
+  const [submitError, setSubmitError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
-    const canvas = canvasRef.current;
+    const canvas = baseRef.current;
     if (!canvas || !image) return;
+    const maskCanvas = maskRef.current;
+    if (!maskCanvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     const img = new Image();
@@ -28,12 +36,37 @@ export default function CanvasDisplay({ image }: { image: File | null }) {
       canvas.height = img.height * scale;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      maskCanvas.width = canvas.width;
+      maskCanvas.height = canvas.height;
+      const mctx = maskCanvas.getContext('2d');
+      mctx?.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
     };
     img.src = URL.createObjectURL(image);
     return () => {
       URL.revokeObjectURL(img.src);
     };
   }, [image]);
+
+  const handleSubmit = async () => {
+    if (!image || !maskRef.current) return;
+    setSubmitting(true);
+    setSubmitMsg('Processing...');
+    setSubmitError('');
+    try {
+      const blob = await new Promise<Blob | null>((resolve) =>
+        maskRef.current!.toBlob(resolve, 'image/png')
+      );
+      const maskFile = blob
+        ? new File([blob], 'mask.png', { type: 'image/png' })
+        : undefined;
+      const result = await processImage(image, maskFile);
+      setSubmitMsg(result.detail || 'Processing complete');
+    } catch (err) {
+      setSubmitError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
 
   return (
     <div className="border rounded p-4 mt-4">
@@ -47,9 +80,32 @@ export default function CanvasDisplay({ image }: { image: File | null }) {
             >
               {mode === 'draw' ? 'Switch to Erase' : 'Switch to Draw'}
             </button>
+            <button
+              type="button"
+              onClick={() => setMaskVisible((v) => !v)}
+              className="px-2 py-1 border rounded"
+            >
+              {maskVisible ? 'Hide Mask' : 'Show Mask'}
+            </button>
             <span className="text-sm text-gray-600">Mode: {mode}</span>
           </div>
-          <canvas ref={canvasRef} className="border" />
+          <div className="relative inline-block">
+            <canvas ref={baseRef} className="border block" />
+            <canvas
+              ref={maskRef}
+              className={`border absolute left-0 top-0 ${maskVisible ? '' : 'hidden'}`}
+            />
+          </div>
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={handleSubmit}
+            className="mt-2 px-2 py-1 border rounded"
+          >
+            Submit
+          </button>
+          {submitMsg && <div className="mt-2 text-green-600">{submitMsg}</div>}
+          {submitError && <div className="mt-2 text-red-600">Error: {submitError}</div>}
         </>
       ) : (
         <div>No image uploaded yet.</div>

--- a/frontend/src/hooks/useCanvas.test.tsx
+++ b/frontend/src/hooks/useCanvas.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useCanvas from './useCanvas';
+
+describe('useCanvas', () => {
+  it('toggles drawing mode', () => {
+    const { result } = renderHook(() => useCanvas());
+    expect(result.current.mode).toBe('draw');
+    act(() => {
+      result.current.toggleMode();
+    });
+    expect(result.current.mode).toBe('erase');
+  });
+});


### PR DESCRIPTION
## Summary
- toggle visibility of mask layer and add submit workflow
- implement hook and component tests
- update task list to reflect completed work

## Testing
- `npm --prefix frontend run lint`
- `flake8`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c5a291110833187c5e072933fbe42