### PR TITLE
Implement basic OpenAI service

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -90,6 +90,7 @@
 - `backend/app/main.py` - Include new OpenAI integration router.
 - `backend/app/core/config.py` - Add OpenAI API key configuration.
 - `backend/requirements.txt` - Add OpenAI Python SDK and related dependencies.
+- `DEVELOPMENT.md` - Document OPENAI_API_KEY configuration.
 - `frontend/package.json` - Add any required frontend dependencies for enhanced UI.
 - `.project-management/current-prd/tasks-prd-core-functionality-epic.md` - Task tracking updates.
 - `CHANGELOG.md` - Document Phase 2 implementation progress.
@@ -104,12 +105,12 @@
 ## Tasks
 
 - [ ] 1.0 Set Up OpenAI Integration Foundation (FR1, FR4, FR5)
-  - [ ] 1.1 Add OpenAI Python SDK to `backend/requirements.txt`
-  - [ ] 1.2 Update `backend/app/core/config.py` to include OpenAI API key from environment
-  - [ ] 1.3 Create `backend/services/openai_service.py` with basic API client setup
+  - [x] 1.1 Add OpenAI Python SDK to `backend/requirements.txt`
+  - [x] 1.2 Update `backend/app/core/config.py` to include OpenAI API key from environment
+  - [x] 1.3 Create `backend/services/openai_service.py` with basic API client setup
   - [ ] 1.4 Add proper logging configuration for OpenAI API requests and responses
-  - [ ] 1.5 Create unit tests for OpenAI service configuration and connection
-  - [ ] 1.6 Update environment setup documentation for API key requirements
+  - [x] 1.5 Create unit tests for OpenAI service configuration and connection
+  - [x] 1.6 Update environment setup documentation for API key requirements
 
 - [ ] 2.0 Implement Core OpenAI Image Editing Integration (FR1, FR2, FR3)
   - [ ] 2.1 Implement image editing function in `openai_service.py` using OpenAI SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 2025-06-13 Added erase mode toggle and canvas styling
 2025-06-13 Added mask layer toggle, submit workflow, and canvas tests
 2025-06-13 Completed setup review tasks
+2025-06-14 Added OpenAI service skeleton and tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,6 +13,9 @@ Create a virtual environment in `backend/.venv` and install requirements:
 python3 -m venv backend/.venv
 source backend/.venv/bin/activate
 pip install -r backend/requirements.txt
+
+# Configure environment variables
+cp backend/.env.example backend/.env  # edit OPENAI_API_KEY with your key
 ```
 
 Start the server using Uvicorn:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ pytest
 flake8
 httpx
 python-multipart
+openai

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -1,0 +1,31 @@
+"""OpenAI API client service."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import openai
+
+from backend.app.core.config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIService:
+    """Simple wrapper around the OpenAI Async API client."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        settings = get_settings()
+        key = api_key or settings.openai_api_key
+        if not key:
+            raise ValueError("OpenAI API key is not configured")
+        self._client = openai.AsyncOpenAI(api_key=key)
+
+    async def verify_connection(self) -> dict[str, Any]:
+        """Perform a trivial API call to verify credentials.
+
+        The call is mocked during tests and does not require network access.
+        """
+        logger.debug("Verifying OpenAI credentials")
+        return await self._client.models.list()

--- a/backend/tests/services/test_openai_service.py
+++ b/backend/tests/services/test_openai_service.py
@@ -1,0 +1,52 @@
+import importlib
+import sys
+import types
+import pytest
+
+
+class DummyModels:
+    async def list(self):
+        return {"object": "list"}
+
+
+class DummyClient:
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+        self.models = DummyModels()
+
+
+def load_service(monkeypatch: pytest.MonkeyPatch, client_factory) -> types.ModuleType:
+    """Reload openai_service with a patched openai module."""
+    fake_openai = types.SimpleNamespace(AsyncOpenAI=client_factory)
+    monkeypatch.setitem(sys.modules, "openai", fake_openai)
+    module = importlib.import_module("backend.services.openai_service")
+    return importlib.reload(module)
+
+
+@pytest.mark.asyncio
+async def test_verify_connection(monkeypatch):
+    calls = {}
+
+    def factory(api_key: str) -> DummyClient:
+        calls["key"] = api_key
+        return DummyClient(api_key)
+
+    service_module = load_service(monkeypatch, factory)
+    service = service_module.OpenAIService(api_key="test-key")
+    result = await service.verify_connection()
+    assert calls["key"] == "test-key"
+    assert result == {"object": "list"}
+
+
+def test_missing_key(monkeypatch):
+    service_module = load_service(monkeypatch, lambda api_key: DummyClient(api_key))
+
+    class DummySettings:
+        openai_api_key = None
+
+    monkeypatch.setattr(
+        service_module, "get_settings", lambda: DummySettings()
+    )
+
+    with pytest.raises(ValueError):
+        service_module.OpenAIService()


### PR DESCRIPTION
## Summary
- start tracking progress on OpenAI integration tasks
- add OpenAI SDK dependency
- implement `OpenAIService` with connection verification
- add tests for the new service
- document OPENAI_API_KEY setup in development guide
- record changes in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c5ff5f04c8331bc052de8425c3026