### PR TITLE
Add logging configuration for OpenAI service

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -79,6 +79,7 @@
 - `frontend/src/components/ErrorBoundary.test.tsx` - Unit tests for `ErrorBoundary` component.
 - `backend/app/api/v1/endpoints/openai_integration.py` - OpenAI API integration endpoints.
 - `backend/services/openai_service.py` - Service for handling OpenAI API calls.
+- `backend/app/logging.py` - Logging configuration utilities.
 - `backend/tests/api/v1/test_openai_integration.py` - Unit tests for OpenAI integration endpoints.
 - `backend/tests/services/test_openai_service.py` - Unit tests for OpenAI service.
 
@@ -104,11 +105,11 @@
 
 ## Tasks
 
-- [ ] 1.0 Set Up OpenAI Integration Foundation (FR1, FR4, FR5)
+- [x] 1.0 Set Up OpenAI Integration Foundation (FR1, FR4, FR5)
   - [x] 1.1 Add OpenAI Python SDK to `backend/requirements.txt`
   - [x] 1.2 Update `backend/app/core/config.py` to include OpenAI API key from environment
   - [x] 1.3 Create `backend/services/openai_service.py` with basic API client setup
-  - [ ] 1.4 Add proper logging configuration for OpenAI API requests and responses
+  - [x] 1.4 Add proper logging configuration for OpenAI API requests and responses
   - [x] 1.5 Create unit tests for OpenAI service configuration and connection
   - [x] 1.6 Update environment setup documentation for API key requirements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 2025-06-13 Added mask layer toggle, submit workflow, and canvas tests
 2025-06-13 Completed setup review tasks
 2025-06-14 Added OpenAI service skeleton and tests
+2025-06-14 Added logging configuration for OpenAI service

--- a/backend/app/logging.py
+++ b/backend/app/logging.py
@@ -1,0 +1,19 @@
+"""Application logging configuration utilities."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+
+def setup_logging() -> None:
+    """Configure root logger using LOG_LEVEL env var."""
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=level,
+            format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+        )
+    else:
+        logging.getLogger().setLevel(level)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,11 +3,14 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from .logging import setup_logging
+
 from .core.config import get_settings
 from .api.v1.endpoints.health import router as health_router
 from .api.v1.endpoints.images import router as images_router
 
 settings = get_settings()
+setup_logging()
 
 app = FastAPI(title="Shiny Broccoli API")
 

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -21,11 +21,14 @@ class OpenAIService:
         if not key:
             raise ValueError("OpenAI API key is not configured")
         self._client = openai.AsyncOpenAI(api_key=key)
+        logger.debug("OpenAI client initialized")
 
     async def verify_connection(self) -> dict[str, Any]:
         """Perform a trivial API call to verify credentials.
 
         The call is mocked during tests and does not require network access.
         """
-        logger.debug("Verifying OpenAI credentials")
-        return await self._client.models.list()
+        logger.info("Verifying OpenAI credentials")
+        response = await self._client.models.list()
+        logger.debug("Models list response: %s", response)
+        return response


### PR DESCRIPTION
## Summary
- commit the logging task in the PRD task list
- configure root logging via new `backend/app/logging.py`
- initialize logging in `main.py`
- enhance `OpenAIService` with logging
- document change in `CHANGELOG`

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_684c61624b088331956276408ef1aa0f