### PR TITLE
Implement validation for edit endpoint

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -125,7 +125,7 @@
   - [x] 3.1 Create `backend/app/api/v1/endpoints/openai_integration.py`
   - [x] 3.2 Implement `POST /api/v1/images/edit` endpoint for OpenAI image editing
   - [x] 3.3 Implement `GET /api/v1/images/status/{request_id}` for progress tracking
-  - [ ] 3.4 Add proper request validation for image, mask, and prompt data
+  - [x] 3.4 Add proper request validation for image, mask, and prompt data
   - [ ] 3.5 Implement async processing for long-running OpenAI requests
   - [ ] 3.6 Add comprehensive error handling and status code mapping
   - [x] 3.7 Include the new OpenAI router in `backend/app/main.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@
 2025-06-14 Added logging configuration for OpenAI service
 2025-06-13 Added OpenAI edit endpoint and router
 2025-06-13 Added status endpoint and tests
+2025-06-14 Added request validation for image edit endpoint with tests

--- a/backend/app/api/v1/endpoints/openai_integration.py
+++ b/backend/app/api/v1/endpoints/openai_integration.py
@@ -21,6 +21,26 @@ async def edit_image(
     prompt: str = Form(""),
 ):
     """Edit an image using OpenAI's API."""
+    if image.content_type not in {"image/png", "image/jpeg", "image/jpg"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported image format",
+        )
+    if mask is not None and mask.content_type not in {"image/png"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Mask must be PNG",
+        )
+    if not prompt.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Prompt is required",
+        )
+    if len(prompt) > 1000:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Prompt too long",
+        )
     start = time.time()
     logger.info("/images/edit called")
     service = OpenAIService()

--- a/backend/tests/api/v1/test_openai_integration.py
+++ b/backend/tests/api/v1/test_openai_integration.py
@@ -23,6 +23,43 @@ def test_edit_image(client, monkeypatch):
     assert response.json() == {"detail": "editing not implemented"}
 
 
+def test_edit_image_invalid_type(client, monkeypatch):
+    patch_service(monkeypatch)
+    file_content = io.BytesIO(b"data")
+    response = client.post(
+        "/api/v1/images/edit",
+        files={"image": ("test.txt", file_content, "text/plain")},
+        data={"prompt": "edit"},
+    )
+    assert response.status_code == 400
+
+
+def test_edit_image_missing_prompt(client, monkeypatch):
+    patch_service(monkeypatch)
+    file_content = io.BytesIO(b"data")
+    response = client.post(
+        "/api/v1/images/edit",
+        files={"image": ("test.png", file_content, "image/png")},
+        data={"prompt": ""},
+    )
+    assert response.status_code == 400
+
+
+def test_edit_image_invalid_mask(client, monkeypatch):
+    patch_service(monkeypatch)
+    file_content = io.BytesIO(b"data")
+    mask_content = io.BytesIO(b"data")
+    response = client.post(
+        "/api/v1/images/edit",
+        files={
+            "image": ("test.png", file_content, "image/png"),
+            "mask": ("mask.jpg", mask_content, "image/jpeg"),
+        },
+        data={"prompt": "edit"},
+    )
+    assert response.status_code == 400
+
+
 def test_get_status(client):
     response = client.get("/api/v1/images/status/abc123")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- commit to implement request validation
- add request validation logic to `/images/edit`
- test invalid image types, masks and prompts
- record request validation changes in CHANGELOG
- mark API validation task complete

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c6706ee0c8331ac395f9f53b3c524