### PR TITLE
Implement mask clearing feature

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -86,6 +86,7 @@
 ### Existing Files Modified
 - `frontend/src/components/CanvasDisplay.tsx` - Enhanced with advanced mask tools and export functionality.
 - `frontend/src/hooks/useCanvas.ts` - Extended with undo/redo, advanced drawing tools, and mask export.
+- `frontend/src/hooks/useCanvas.test.tsx` - Tests for canvas hook functionality.
 - `frontend/src/pages/HomePage.tsx` - Integration of new components into complete workflow.
 - `frontend/src/services/apiClient.ts` - Added functions for OpenAI integration endpoints.
 - `backend/app/main.py` - Include new OpenAI integration router.
@@ -95,6 +96,7 @@
 - `frontend/package.json` - Add any required frontend dependencies for enhanced UI.
 - `.project-management/current-prd/tasks-prd-core-functionality-epic.md` - Task tracking updates.
 - `CHANGELOG.md` - Document Phase 2 implementation progress.
+- `frontend/src/components/CanvasDisplay.test.tsx` - Unit tests for CanvasDisplay component.
 
 ### Notes
 - OpenAI API key must be stored securely in environment variables
@@ -134,7 +136,7 @@
 - [ ] 4.0 Enhance Mask Drawing System (FR6-FR10, US2, US6)
   - [ ] 4.1 Create `MaskToolbar.tsx` component with brush size controls (small, medium, large)
   - [ ] 4.2 Implement rectangle and circle selection tools in addition to freehand drawing
-  - [ ] 4.3 Add "Clear Mask" functionality to reset the entire mask
+  - [x] 4.3 Add "Clear Mask" functionality to reset the entire mask
   - [ ] 4.4 Implement undo/redo system for mask operations
   - [ ] 4.5 Enhance `useCanvas.ts` hook with advanced drawing state management
   - [ ] 4.6 Add mask export functionality to generate proper PNG data for API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 2025-06-13 Added status endpoint and tests
 2025-06-14 Added request validation for image edit endpoint with tests
 2025-06-13 Implemented PromptInput component with validation
+2025-06-14 Added clear mask functionality and tests

--- a/frontend/src/components/CanvasDisplay.test.tsx
+++ b/frontend/src/components/CanvasDisplay.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import CanvasDisplay from './CanvasDisplay';
 
 vi.stubGlobal('Image', class {
@@ -11,14 +11,24 @@ vi.stubGlobal('Image', class {
   }
 });
 
-HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
-  clearRect: vi.fn(),
-  drawImage: vi.fn(),
-  beginPath: vi.fn(),
-  moveTo: vi.fn(),
-  lineTo: vi.fn(),
-  stroke: vi.fn(),
-} as unknown as CanvasRenderingContext2D));
+const contexts: any[] = [];
+HTMLCanvasElement.prototype.getContext = vi.fn(function () {
+  const ctx = {
+    clearRect: vi.fn(),
+    drawImage: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+  } as unknown as CanvasRenderingContext2D;
+  contexts.push(ctx);
+  return ctx;
+});
+
+afterEach(() => {
+  cleanup();
+  contexts.length = 0;
+});
 
 HTMLCanvasElement.prototype.toBlob = vi.fn(function (cb) {
   cb?.(new Blob());
@@ -41,5 +51,15 @@ describe('CanvasDisplay', () => {
     expect(toggle.textContent).toBe('Show Mask');
     fireEvent.click(getByText('Submit'));
     await waitFor(() => getByText('ok'));
+  });
+
+  it('clears the mask canvas', async () => {
+    const file = new File(['data'], 'test.png', { type: 'image/png' });
+    const { getByText } = render(<CanvasDisplay image={file} />);
+    await waitFor(() => getByText('Clear Mask'));
+    const clearBtn = getByText('Clear Mask');
+    const maskCtx = contexts[1];
+    fireEvent.click(clearBtn);
+    expect(maskCtx.clearRect).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/CanvasDisplay.tsx
+++ b/frontend/src/components/CanvasDisplay.tsx
@@ -10,7 +10,7 @@ import { processImage } from '../services/apiClient';
 
 export default function CanvasDisplay({ image }: { image: File | null }) {
   const baseRef = useRef<HTMLCanvasElement>(null);
-  const { canvasRef: maskRef, mode, toggleMode } = useCanvas();
+  const { canvasRef: maskRef, mode, toggleMode, clear } = useCanvas();
   const [maskVisible, setMaskVisible] = useState(true);
   const [submitMsg, setSubmitMsg] = useState('');
   const [submitError, setSubmitError] = useState('');
@@ -86,6 +86,13 @@ export default function CanvasDisplay({ image }: { image: File | null }) {
               className="px-2 py-1 border rounded"
             >
               {maskVisible ? 'Hide Mask' : 'Show Mask'}
+            </button>
+            <button
+              type="button"
+              onClick={clear}
+              className="px-2 py-1 border rounded"
+            >
+              Clear Mask
             </button>
             <span className="text-sm text-gray-600">Mode: {mode}</span>
           </div>

--- a/frontend/src/hooks/useCanvas.test.tsx
+++ b/frontend/src/hooks/useCanvas.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import useCanvas from './useCanvas';
 
@@ -10,5 +10,17 @@ describe('useCanvas', () => {
       result.current.toggleMode();
     });
     expect(result.current.mode).toBe('erase');
+  });
+
+  it('clears the canvas', () => {
+    const { result } = renderHook(() => useCanvas());
+    const canvas = document.createElement('canvas');
+    const clearRect = vi.fn();
+    canvas.getContext = vi.fn(() => ({ clearRect } as unknown as CanvasRenderingContext2D));
+    result.current.canvasRef.current = canvas;
+    act(() => {
+      result.current.clear();
+    });
+    expect(clearRect).toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/useCanvas.ts
+++ b/frontend/src/hooks/useCanvas.ts
@@ -9,6 +9,12 @@ export default function useCanvas() {
   const drawing = useRef(false);
   const [mode, setMode] = useState<'draw' | 'erase'>('draw');
   const toggleMode = () => setMode((m) => (m === 'draw' ? 'erase' : 'draw'));
+  const clear = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    ctx?.clearRect(0, 0, canvas.width, canvas.height);
+  };
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -49,5 +55,5 @@ export default function useCanvas() {
     };
   }, [mode]);
 
-  return { canvasRef, mode, toggleMode };
+  return { canvasRef, mode, toggleMode, clear };
 }


### PR DESCRIPTION
## Summary
- add clear mask button in CanvasDisplay
- expose `clear` helper from useCanvas hook
- test the new hook behaviour and CanvasDisplay button
- document changes in task list and CHANGELOG

## Testing
- `flake8`
- `npm run lint` in `frontend`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c69c602f08331b1410e5e40e559e0