### PR TITLE
Implement OpenAI image edit service

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -90,6 +90,8 @@
 - `frontend/src/pages/HomePage.tsx` - Integration of new components into complete workflow.
 - `frontend/src/services/apiClient.ts` - Added functions for OpenAI integration endpoints.
 - `backend/app/main.py` - Include new OpenAI integration router.
+- `backend/app/api/v1/endpoints/openai_integration.py` - OpenAI API integration endpoints.
+- `backend/services/openai_service.py` - Service for handling OpenAI API calls.
 - `backend/app/core/config.py` - Add OpenAI API key configuration.
 - `backend/requirements.txt` - Add OpenAI Python SDK and related dependencies.
 - `DEVELOPMENT.md` - Document OPENAI_API_KEY configuration.
@@ -97,6 +99,8 @@
 - `.project-management/current-prd/tasks-prd-core-functionality-epic.md` - Task tracking updates.
 - `CHANGELOG.md` - Document Phase 2 implementation progress.
 - `frontend/src/components/CanvasDisplay.test.tsx` - Unit tests for CanvasDisplay component.
+- `backend/tests/api/v1/test_openai_integration.py` - Unit tests for OpenAI integration endpoints.
+- `backend/tests/services/test_openai_service.py` - Unit tests for OpenAI service.
 
 ### Notes
 - OpenAI API key must be stored securely in environment variables
@@ -116,11 +120,11 @@
   - [x] 1.6 Update environment setup documentation for API key requirements
 
 - [ ] 2.0 Implement Core OpenAI Image Editing Integration (FR1, FR2, FR3)
-  - [ ] 2.1 Implement image editing function in `openai_service.py` using OpenAI SDK
+  - [c] 2.1 Implement image editing function in `openai_service.py` using OpenAI SDK
   - [ ] 2.2 Add proper image format conversion (canvas to PNG) for OpenAI compatibility
-  - [ ] 2.3 Handle OpenAI API responses including success, error, and timeout scenarios
+  - [c] 2.3 Handle OpenAI API responses including success, error, and timeout scenarios
   - [ ] 2.4 Implement request/response validation and error mapping
-  - [ ] 2.5 Add comprehensive unit tests for OpenAI service functions
+  - [c] 2.5 Add comprehensive unit tests for OpenAI service functions
   - [ ] 2.6 Test integration with various image sizes and mask complexities
 
 - [ ] 3.0 Create OpenAI API Endpoints (FR1-FR5, US5, US7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@
 2025-06-14 Added request validation for image edit endpoint with tests
 2025-06-13 Implemented PromptInput component with validation
 2025-06-14 Added clear mask functionality and tests
+2025-06-13 Added image editing service and endpoint implementation

--- a/backend/app/api/v1/endpoints/openai_integration.py
+++ b/backend/app/api/v1/endpoints/openai_integration.py
@@ -45,8 +45,9 @@ async def edit_image(
     logger.info("/images/edit called")
     service = OpenAIService()
     try:
-        # Placeholder call until editing support is implemented
-        await service.verify_connection()
+        img_bytes = await image.read()
+        mask_bytes = await mask.read() if mask else None
+        result = await service.edit_image(img_bytes, mask_bytes, prompt)
     except Exception as exc:  # pragma: no cover - should not occur in tests
         logger.exception("OpenAI edit failed")
         raise HTTPException(
@@ -54,7 +55,7 @@ async def edit_image(
             detail=str(exc),
         )
     logger.info("/images/edit completed in %.3f", time.time() - start)
-    return {"detail": "editing not implemented"}
+    return result
 
 
 @router.get("/images/status/{request_id}")

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -32,3 +32,30 @@ class OpenAIService:
         response = await self._client.models.list()
         logger.debug("Models list response: %s", response)
         return response
+
+    async def edit_image(
+        self, image: bytes, mask: bytes | None, prompt: str
+    ) -> dict[str, Any]:
+        """Send an image edit request to OpenAI.
+
+        Parameters
+        ----------
+        image:
+            The base image data in bytes.
+        mask:
+            Optional mask image data in bytes.
+        prompt:
+            The editing prompt to apply.
+        """
+        logger.info("Sending image edit request")
+        try:
+            response = await self._client.images.edit(
+                image=image,
+                mask=mask,
+                prompt=prompt,
+            )
+        except Exception:  # pragma: no cover - network errors mocked in tests
+            logger.exception("OpenAI image edit failed")
+            raise
+        logger.debug("Image edit response: %s", response)
+        return response

--- a/backend/tests/api/v1/test_openai_integration.py
+++ b/backend/tests/api/v1/test_openai_integration.py
@@ -3,8 +3,11 @@ from backend.app.api.v1.endpoints import openai_integration
 
 
 class DummyService:
-    async def verify_connection(self):
-        return {"object": "list"}
+    async def edit_image(self, image: bytes, mask: bytes | None, prompt: str):
+        assert image == b"data"
+        assert mask is None
+        assert prompt == "edit"
+        return {"detail": "ok"}
 
 
 def patch_service(monkeypatch):
@@ -20,7 +23,7 @@ def test_edit_image(client, monkeypatch):
         data={"prompt": "edit"},
     )
     assert response.status_code == 200
-    assert response.json() == {"detail": "editing not implemented"}
+    assert response.json() == {"detail": "ok"}
 
 
 def test_edit_image_invalid_type(client, monkeypatch):

--- a/backend/tests/services/test_openai_service.py
+++ b/backend/tests/services/test_openai_service.py
@@ -50,3 +50,27 @@ def test_missing_key(monkeypatch):
 
     with pytest.raises(ValueError):
         service_module.OpenAIService()
+
+
+@pytest.mark.asyncio
+async def test_edit_image(monkeypatch):
+    calls = {}
+
+    class DummyImages:
+        async def edit(self, *, image, mask=None, prompt):
+            calls["image"] = image
+            calls["mask"] = mask
+            calls["prompt"] = prompt
+            return {"result": "ok"}
+
+    class Client(DummyClient):
+        def __init__(self, api_key: str) -> None:
+            super().__init__(api_key)
+            self.images = DummyImages()
+
+    service_module = load_service(monkeypatch, Client)
+    service = service_module.OpenAIService(api_key="k")
+    result = await service.edit_image(b"img", b"mask", "p")
+
+    assert result == {"result": "ok"}
+    assert calls == {"image": b"img", "mask": b"mask", "prompt": "p"}


### PR DESCRIPTION
## Summary
- update tasks to commit OpenAI editing subtasks
- implement image edit function in the service
- call the new function from the edit endpoint
- add tests for edit service and endpoint
- document the change in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c6bfa869483318a6daa00b868d12d