### PR TITLE
Implement recent prompt history with examples

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -150,8 +150,8 @@
 - [ ] 5.0 Implement Prompt Engineering Interface (FR11-FR14, US1, US4)
 - [x] 5.1 Create `PromptInput.tsx` component with text area and validation
 - [x] 5.2 Add prompt length validation and character counter
-  - [ ] 5.3 Implement recent prompts storage and quick reuse functionality
-  - [ ] 5.4 Add example prompts and guidance text for new users
+  - [x] 5.3 Implement recent prompts storage and quick reuse functionality
+  - [x] 5.4 Add example prompts and guidance text for new users
   - [ ] 5.5 Include prompt suggestions based on common editing tasks
 - [x] 5.6 Create unit tests for prompt input validation and storage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
 2025-06-13 Added image editing service and endpoint implementation
 2025-06-15 Added OpenAI edit API client functions and updated tasks
 2025-06-15 Added mask toolbar with brush size controls
+2025-06-15 Added prompt history with example suggestions

--- a/frontend/src/components/PromptInput.test.tsx
+++ b/frontend/src/components/PromptInput.test.tsx
@@ -5,6 +5,7 @@ import PromptInput from './PromptInput';
 describe('PromptInput', () => {
   afterEach(() => {
     cleanup();
+    localStorage.clear();
   });
   it('submits valid prompt', () => {
     const submit = vi.fn();
@@ -19,5 +20,19 @@ describe('PromptInput', () => {
     const { getByText } = render(<PromptInput />);
     fireEvent.submit(getByText('Submit').closest('form') as HTMLFormElement);
     expect(getByText('Error: Prompt is required')).toBeTruthy();
+  });
+
+  it('shows example prompts when none stored', () => {
+    const { getByText } = render(<PromptInput />);
+    expect(getByText(/Example prompts/i)).toBeTruthy();
+  });
+
+  it('stores prompt and displays recent list', () => {
+    const { getByText, getByLabelText } = render(<PromptInput />);
+    const textarea = getByLabelText('Prompt');
+    fireEvent.change(textarea, { target: { value: 'hello' } });
+    fireEvent.submit(getByText('Submit').closest('form') as HTMLFormElement);
+    expect(localStorage.getItem('recentPrompts')).toContain('hello');
+    expect(getByText(/Recent prompts/i)).toBeTruthy();
   });
 });

--- a/frontend/src/components/PromptInput.tsx
+++ b/frontend/src/components/PromptInput.tsx
@@ -1,4 +1,4 @@
-import { useState, FormEvent, ChangeEvent } from 'react';
+import { useState, useEffect, FormEvent, ChangeEvent } from 'react';
 
 /**
  * Prompt input component with basic validation and character counter.
@@ -12,6 +12,18 @@ export default function PromptInput({
 }) {
   const [prompt, setPrompt] = useState('');
   const [error, setError] = useState('');
+  const [recent, setRecent] = useState<string[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('recentPrompts');
+    if (stored) {
+      try {
+        setRecent(JSON.parse(stored));
+      } catch {
+        setRecent([]);
+      }
+    }
+  }, []);
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
@@ -31,7 +43,11 @@ export default function PromptInput({
       setError(!prompt.trim() ? 'Prompt is required' : 'Prompt too long');
       return;
     }
-    onSubmit?.(prompt.trim());
+    const clean = prompt.trim();
+    onSubmit?.(clean);
+    const updated = [clean, ...recent.filter((p) => p !== clean)].slice(0, 5);
+    setRecent(updated);
+    localStorage.setItem('recentPrompts', JSON.stringify(updated));
     setPrompt('');
   };
 
@@ -46,6 +62,42 @@ export default function PromptInput({
       />
       <div className="text-sm text-gray-600 mt-1">
         {prompt.length}/{maxLength}
+      </div>
+      <div className="my-2">
+        {recent.length === 0 ? (
+          <div className="text-sm text-gray-600">
+            Example prompts:
+            <button
+              type="button"
+              className="ml-2 underline"
+              onClick={() => setPrompt('Remove the background')}
+            >
+              Remove the background
+            </button>
+            ,
+            <button
+              type="button"
+              className="ml-1 underline"
+              onClick={() => setPrompt('Change sky color to blue')}
+            >
+              Change sky color
+            </button>
+          </div>
+        ) : (
+          <div className="text-sm text-gray-600">
+            Recent prompts:
+            {recent.map((p) => (
+              <button
+                key={p}
+                type="button"
+                className="ml-2 underline"
+                onClick={() => setPrompt(p)}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
       <button
         type="submit"


### PR DESCRIPTION
## Summary
- store recently submitted prompts and offer example prompts
- update tests for PromptInput
- mark tasks 5.3 and 5.4 complete
- update changelog

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c72634f688331b8ecdbcf4c9311b7