### PR TITLE
Implement PNG mask export and convert images

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -121,7 +121,7 @@
 
 - [ ] 2.0 Implement Core OpenAI Image Editing Integration (FR1, FR2, FR3)
   - [x] 2.1 Implement image editing function in `openai_service.py` using OpenAI SDK
-  - [ ] 2.2 Add proper image format conversion (canvas to PNG) for OpenAI compatibility
+  - [x] 2.2 Add proper image format conversion (canvas to PNG) for OpenAI compatibility
   - [x] 2.3 Handle OpenAI API responses including success, error, and timeout scenarios
   - [ ] 2.4 Implement request/response validation and error mapping
   - [x] 2.5 Add comprehensive unit tests for OpenAI service functions
@@ -143,7 +143,7 @@
   - [x] 4.3 Add "Clear Mask" functionality to reset the entire mask
   - [ ] 4.4 Implement undo/redo system for mask operations
   - [x] 4.5 Enhance `useCanvas.ts` hook with advanced drawing state management
-  - [ ] 4.6 Add mask export functionality to generate proper PNG data for API
+  - [x] 4.6 Add mask export functionality to generate proper PNG data for API
   - [x] 4.7 Update `CanvasDisplay.tsx` to integrate with new toolbar and tools
   - [ ] 4.8 Create comprehensive unit tests for enhanced mask functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@
 2025-06-15 Added OpenAI edit API client functions and updated tasks
 2025-06-15 Added mask toolbar with brush size controls
 2025-06-15 Added prompt history with example suggestions
+2025-06-15 Improved mask export and PNG conversion for OpenAI edits

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ flake8
 httpx
 python-multipart
 openai
+Pillow

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -3,7 +3,13 @@
 from __future__ import annotations
 
 import logging
+from io import BytesIO
 from typing import Any
+
+try:  # Pillow is optional in test environments
+    from PIL import Image
+except Exception:  # pragma: no cover - pillow may not be installed
+    Image = None  # type: ignore
 
 import openai
 
@@ -33,6 +39,17 @@ class OpenAIService:
         logger.debug("Models list response: %s", response)
         return response
 
+    def _ensure_png(self, data: bytes) -> bytes:
+        """Convert image bytes to PNG if not already."""
+        if Image is None:  # pragma: no cover - Pillow not installed
+            return data
+        img = Image.open(BytesIO(data))
+        if img.format != "PNG":
+            buf = BytesIO()
+            img.save(buf, format="PNG")
+            return buf.getvalue()
+        return data
+
     async def edit_image(
         self, image: bytes, mask: bytes | None, prompt: str
     ) -> dict[str, Any]:
@@ -49,9 +66,11 @@ class OpenAIService:
         """
         logger.info("Sending image edit request")
         try:
+            png_image = self._ensure_png(image)
+            png_mask = self._ensure_png(mask) if mask else None
             response = await self._client.images.edit(
-                image=image,
-                mask=mask,
+                image=png_image,
+                mask=png_mask,
                 prompt=prompt,
             )
         except Exception:  # pragma: no cover - network errors mocked in tests

--- a/backend/tests/services/test_openai_service.py
+++ b/backend/tests/services/test_openai_service.py
@@ -70,6 +70,7 @@ async def test_edit_image(monkeypatch):
 
     service_module = load_service(monkeypatch, Client)
     service = service_module.OpenAIService(api_key="k")
+    monkeypatch.setattr(service, "_ensure_png", lambda d: d)
     result = await service.edit_image(b"img", b"mask", "p")
 
     assert result == {"result": "ok"}

--- a/frontend/src/components/CanvasDisplay.test.tsx
+++ b/frontend/src/components/CanvasDisplay.test.tsx
@@ -15,6 +15,7 @@ const contexts: any[] = [];
 HTMLCanvasElement.prototype.getContext = vi.fn(function () {
   const ctx = {
     clearRect: vi.fn(),
+    fillRect: vi.fn(),
     drawImage: vi.fn(),
     beginPath: vi.fn(),
     moveTo: vi.fn(),
@@ -35,7 +36,7 @@ HTMLCanvasElement.prototype.toBlob = vi.fn(function (cb) {
 });
 
 vi.mock('../services/apiClient', () => ({
-  processImage: vi.fn(() => Promise.resolve({ detail: 'ok' })),
+  editImage: vi.fn(() => Promise.resolve({ detail: 'ok' })),
 }));
 
 global.URL.createObjectURL = vi.fn(() => 'blob:url');
@@ -67,8 +68,8 @@ describe('CanvasDisplay', () => {
     const { getByText } = render(<CanvasDisplay image={file} />);
     await waitFor(() => getByText('Clear Mask'));
     const clearBtn = getByText('Clear Mask');
-    const maskCtx = contexts[1];
     fireEvent.click(clearBtn);
-    expect(maskCtx.clearRect).toHaveBeenCalled();
+    const called = contexts.some((ctx) => ctx.fillRect.mock.calls.length > 0);
+    expect(called).toBe(true);
   });
 });

--- a/frontend/src/components/CanvasDisplay.tsx
+++ b/frontend/src/components/CanvasDisplay.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import useCanvas from '../hooks/useCanvas';
 import MaskToolbar from './MaskToolbar';
-import { processImage } from '../services/apiClient';
+import { editImage } from '../services/apiClient';
 
 /**
  * Displays an uploaded image on an HTML5 canvas.
@@ -47,7 +47,11 @@ export default function CanvasDisplay({ image }: { image: File | null }) {
       maskCanvas.width = canvas.width;
       maskCanvas.height = canvas.height;
       const mctx = maskCanvas.getContext('2d');
-      mctx?.clearRect(0, 0, maskCanvas.width, maskCanvas.height);
+      if (mctx) {
+        mctx.fillStyle = 'white';
+        mctx.fillRect(0, 0, maskCanvas.width, maskCanvas.height);
+      }
+      maskCanvas.style.opacity = '0.5';
     };
     img.src = URL.createObjectURL(image);
     return () => {
@@ -56,18 +60,26 @@ export default function CanvasDisplay({ image }: { image: File | null }) {
   }, [image]);
 
   const handleSubmit = async () => {
-    if (!image || !maskRef.current) return;
+    if (!image || !maskRef.current || !baseRef.current) return;
     setSubmitting(true);
     setSubmitMsg('Processing...');
     setSubmitError('');
     try {
-      const blob = await new Promise<Blob | null>((resolve) =>
-        maskRef.current!.toBlob(resolve, 'image/png')
-      );
-      const maskFile = blob
-        ? new File([blob], 'mask.png', { type: 'image/png' })
+      const [maskBlob, imgBlob] = await Promise.all([
+        new Promise<Blob | null>((resolve) =>
+          maskRef.current!.toBlob(resolve, 'image/png')
+        ),
+        new Promise<Blob | null>((resolve) =>
+          baseRef.current!.toBlob(resolve, 'image/png')
+        ),
+      ]);
+      const maskFile = maskBlob
+        ? new File([maskBlob], 'mask.png', { type: 'image/png' })
         : undefined;
-      const result = await processImage(image, maskFile);
+      const imageFile = imgBlob
+        ? new File([imgBlob], 'image.png', { type: 'image/png' })
+        : image;
+      const result = await editImage(imageFile, 'Edit', maskFile);
       setSubmitMsg(result.detail || 'Processing complete');
     } catch (err) {
       setSubmitError((err as Error).message);

--- a/frontend/src/hooks/useCanvas.test.tsx
+++ b/frontend/src/hooks/useCanvas.test.tsx
@@ -15,13 +15,13 @@ describe('useCanvas', () => {
   it('clears the canvas', () => {
     const { result } = renderHook(() => useCanvas());
     const canvas = document.createElement('canvas');
-    const clearRect = vi.fn();
-    canvas.getContext = vi.fn(() => ({ clearRect } as unknown as CanvasRenderingContext2D));
+    const fillRect = vi.fn();
+    canvas.getContext = vi.fn(() => ({ fillRect, globalCompositeOperation: 'source-over', fillStyle: 'white' } as unknown as CanvasRenderingContext2D));
     result.current.canvasRef.current = canvas;
     act(() => {
       result.current.clear();
     });
-    expect(clearRect).toHaveBeenCalled();
+    expect(fillRect).toHaveBeenCalled();
   });
 
   it('updates brush size', () => {

--- a/frontend/src/hooks/useCanvas.ts
+++ b/frontend/src/hooks/useCanvas.ts
@@ -12,11 +12,19 @@ export default function useCanvas() {
   const [mode, setMode] = useState<'draw' | 'erase'>('draw');
   const [brushSize, setBrushSize] = useState<BrushSize>('medium');
   const toggleMode = () => setMode((m) => (m === 'draw' ? 'erase' : 'draw'));
+
+  const fillWhite = (ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement) => {
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  };
+
   const clear = () => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
-    ctx?.clearRect(0, 0, canvas.width, canvas.height);
+    if (!ctx) return;
+    fillWhite(ctx, canvas);
   };
 
   useEffect(() => {
@@ -24,6 +32,10 @@ export default function useCanvas() {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
+
+    // Initialize mask with white so opaque regions are preserved
+    fillWhite(ctx, canvas);
+    canvas.style.opacity = '0.5';
 
     const startDraw = (e: PointerEvent) => {
       drawing.current = true;
@@ -36,8 +48,13 @@ export default function useCanvas() {
       const widthMap = { small: 4, medium: 8, large: 12 } as const;
       ctx.lineWidth = widthMap[brushSize];
       ctx.lineCap = 'round';
-      ctx.strokeStyle = 'red';
-      ctx.globalCompositeOperation = mode === 'erase' ? 'destination-out' : 'source-over';
+      if (mode === 'draw') {
+        ctx.globalCompositeOperation = 'destination-out';
+        ctx.strokeStyle = 'black';
+      } else {
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.strokeStyle = 'white';
+      }
       ctx.lineTo(e.offsetX, e.offsetY);
       ctx.stroke();
     };


### PR DESCRIPTION
## Summary
- make mask canvas export opaque white regions and transparent edits
- convert images and masks to PNG before OpenAI calls
- update tests and requirements
- mark relevant tasks complete

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c75068ab483318a7b74cc6da46072