### PR TITLE
Add progress and results display components

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -156,21 +156,21 @@
 - [x] 5.6 Create unit tests for prompt input validation and storage
 
 - [ ] 6.0 Build Results Display System (FR15-FR18, US3)
-  - [ ] 6.1 Create `ResultsDisplay.tsx` component for before/after comparison
+  - [x] 6.1 Create `ResultsDisplay.tsx` component for before/after comparison
   - [ ] 6.2 Implement side-by-side and overlay comparison modes
   - [ ] 6.3 Add download/save functionality for edited results
   - [ ] 6.4 Handle display of OpenAI error responses and fallback states
   - [ ] 6.5 Optimize image loading and display performance
-  - [ ] 6.6 Create unit tests for results display functionality
+  - [x] 6.6 Create unit tests for results display functionality
 
 - [ ] 7.0 Implement Progress and Error Handling (FR19-FR22, US5, US7)
-  - [ ] 7.1 Create `ProgressIndicator.tsx` component with loading animations
+  - [x] 7.1 Create `ProgressIndicator.tsx` component with loading animations
   - [ ] 7.2 Implement progress tracking for long-running API requests
   - [ ] 7.3 Add estimated completion time display
   - [x] 7.4 Create `ErrorBoundary.tsx` for graceful error recovery
   - [ ] 7.5 Implement retry functionality for failed requests
   - [ ] 7.6 Add user-friendly error messages for different failure scenarios
-  - [ ] 7.7 Create unit tests for progress and error handling components
+  - [x] 7.7 Create unit tests for progress and error handling components
 
 - [ ] 8.0 Frontend-Backend Integration for Complete Workflow (FR1-FR22, US1-US7)
   - [x] 8.1 Update `frontend/src/services/apiClient.ts` with OpenAI integration functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@
 2025-06-15 Added prompt history with example suggestions
 2025-06-15 Improved mask export and PNG conversion for OpenAI edits
 2025-06-15 Added ErrorBoundary component with tests for error handling
+2025-06-13 Added progress and results display components with tests

--- a/frontend/src/components/ProgressIndicator.test.tsx
+++ b/frontend/src/components/ProgressIndicator.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import ProgressIndicator from './ProgressIndicator';
+
+describe('ProgressIndicator', () => {
+  it('renders with default message', () => {
+    const { getByText, getByLabelText } = render(<ProgressIndicator />);
+    expect(getByLabelText('progress-indicator')).toBeTruthy();
+    expect(getByText('Loading...')).toBeTruthy();
+  });
+
+  it('shows custom message and progress', () => {
+    const { getByText } = render(<ProgressIndicator message="Processing" progress={50} />);
+    expect(getByText('Processing')).toBeTruthy();
+    expect(getByText('50%')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/ProgressIndicator.tsx
+++ b/frontend/src/components/ProgressIndicator.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface Props {
+  message?: string;
+  progress?: number; // 0-100
+}
+
+/**
+ * Displays a simple progress indicator with optional message and progress percent.
+ */
+export default function ProgressIndicator({ message = 'Loading...', progress }: Props) {
+  return (
+    <div className="flex items-center gap-2" aria-label="progress-indicator">
+      <svg
+        className="animate-spin h-5 w-5 text-gray-600"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+        />
+      </svg>
+      <span>{message}</span>
+      {progress !== undefined && <span>{progress}%</span>}
+    </div>
+  );
+}

--- a/frontend/src/components/ResultsDisplay.test.tsx
+++ b/frontend/src/components/ResultsDisplay.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import ResultsDisplay from './ResultsDisplay';
+
+describe('ResultsDisplay', () => {
+  beforeAll(() => {
+    global.URL.createObjectURL = vi.fn(() => 'blob:url');
+  });
+  it('shows placeholders when no images provided', () => {
+    const { getByText } = render(<ResultsDisplay original={null} result={null} />);
+    expect(getByText('No original')).toBeTruthy();
+    expect(getByText('No result')).toBeTruthy();
+  });
+
+  it('renders provided images', () => {
+    const file = new File(['data'], 'orig.png', { type: 'image/png' });
+    const { getAllByRole } = render(<ResultsDisplay original={file} result={file} />);
+    expect(getAllByRole('img').length).toBe(2);
+  });
+});

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface Props {
+  original: string | File | null;
+  result: string | File | null;
+}
+
+/**
+ * Displays before and after images side by side.
+ */
+export default function ResultsDisplay({ original, result }: Props) {
+  const origUrl =
+    typeof original === 'string'
+      ? original
+      : original
+      ? URL.createObjectURL(original)
+      : null;
+  const resultUrl =
+    typeof result === 'string'
+      ? result
+      : result
+      ? URL.createObjectURL(result)
+      : null;
+  return (
+    <div className="flex gap-4" aria-label="results-display">
+      {origUrl ? <img src={origUrl} alt="original" className="max-w-xs" /> : <div>No original</div>}
+      {resultUrl ? <img src={resultUrl} alt="result" className="max-w-xs" /> : <div>No result</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `ProgressIndicator` component with spinner
- add `ResultsDisplay` component for before/after images
- include unit tests for new components
- mark completed tasks in task list
- document change in CHANGELOG

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_684c796170e883319eb24faeac433990