### PR TITLE
Implement overlay mode for ResultsDisplay

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -157,7 +157,7 @@
 
 - [ ] 6.0 Build Results Display System (FR15-FR18, US3)
   - [x] 6.1 Create `ResultsDisplay.tsx` component for before/after comparison
-  - [ ] 6.2 Implement side-by-side and overlay comparison modes
+  - [x] 6.2 Implement side-by-side and overlay comparison modes
   - [ ] 6.3 Add download/save functionality for edited results
   - [ ] 6.4 Handle display of OpenAI error responses and fallback states
   - [ ] 6.5 Optimize image loading and display performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,4 @@
 2025-06-15 Improved mask export and PNG conversion for OpenAI edits
 2025-06-15 Added ErrorBoundary component with tests for error handling
 2025-06-13 Added progress and results display components with tests
+2025-06-13 Added overlay display mode for results and improved OpenAI tests

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -95,4 +95,7 @@ class OpenAIService:
             logger.exception("OpenAI image edit failed")
             raise
         logger.debug("Image edit response: %s", response)
-        return response.to_dict()
+        try:
+            return response.to_dict()
+        except Exception:
+            return dict(response)

--- a/backend/tests/integration/test_images/test_edit_image.py
+++ b/backend/tests/integration/test_images/test_edit_image.py
@@ -2,6 +2,7 @@ import os
 import pytest
 from backend.services.openai_service import OpenAIService
 
+
 @pytest.mark.asyncio
 async def test_edit_image_integration():
     api_key = os.environ.get("OPENAI_API_KEY")

--- a/backend/tests/integration/test_openai_connectivity.py
+++ b/backend/tests/integration/test_openai_connectivity.py
@@ -3,6 +3,7 @@ import pytest
 
 from backend.services.openai_service import OpenAIService
 
+
 @pytest.mark.asyncio
 async def test_openai_connectivity_integration():
     """

--- a/backend/tests/unit/services/test_openai_service.py
+++ b/backend/tests/unit/services/test_openai_service.py
@@ -63,7 +63,8 @@ def test_missing_key(monkeypatch):
 def test_edit_image(monkeypatch):
     # Minimal valid 1x1 PNG image (transparent)
     png_base64 = (
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ZkAAAAASUVORK5CYII="
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+"
+        "X2ZkAAAAASUVORK5CYII="
     )
     png_bytes = base64.b64decode(png_base64)
 

--- a/frontend/src/components/ResultsDisplay.test.tsx
+++ b/frontend/src/components/ResultsDisplay.test.tsx
@@ -1,10 +1,13 @@
-import { describe, it, expect, beforeAll, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
 import ResultsDisplay from './ResultsDisplay';
 
 describe('ResultsDisplay', () => {
   beforeAll(() => {
     global.URL.createObjectURL = vi.fn(() => 'blob:url');
+  });
+  afterEach(() => {
+    cleanup();
   });
   it('shows placeholders when no images provided', () => {
     const { getByText } = render(<ResultsDisplay original={null} result={null} />);
@@ -14,7 +17,14 @@ describe('ResultsDisplay', () => {
 
   it('renders provided images', () => {
     const file = new File(['data'], 'orig.png', { type: 'image/png' });
-    const { getAllByRole } = render(<ResultsDisplay original={file} result={file} />);
+    const { getAllByRole, getByText, getByLabelText } = render(
+      <ResultsDisplay original={file} result={file} />
+    );
+    let container = getByLabelText('results-display');
+    expect(container.getAttribute('data-mode')).toBe('side-by-side');
     expect(getAllByRole('img').length).toBe(2);
+    fireEvent.click(getByText('Overlay'));
+    container = getByLabelText('results-display');
+    expect(container.getAttribute('data-mode')).toBe('overlay');
   });
 });

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 interface Props {
   original: string | File | null;
@@ -9,6 +9,7 @@ interface Props {
  * Displays before and after images side by side.
  */
 export default function ResultsDisplay({ original, result }: Props) {
+  const [mode, setMode] = useState<'side-by-side' | 'overlay'>('side-by-side');
   const origUrl =
     typeof original === 'string'
       ? original
@@ -22,9 +23,43 @@ export default function ResultsDisplay({ original, result }: Props) {
       ? URL.createObjectURL(result)
       : null;
   return (
-    <div className="flex gap-4" aria-label="results-display">
-      {origUrl ? <img src={origUrl} alt="original" className="max-w-xs" /> : <div>No original</div>}
-      {resultUrl ? <img src={resultUrl} alt="result" className="max-w-xs" /> : <div>No result</div>}
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          setMode((m) => (m === 'side-by-side' ? 'overlay' : 'side-by-side'))
+        }
+        className="mb-2 px-2 py-1 border rounded"
+      >
+        {mode === 'side-by-side' ? 'Overlay' : 'Side by Side'}
+      </button>
+      {mode === 'side-by-side' ? (
+        <div className="flex gap-4" aria-label="results-display" data-mode="side-by-side">
+          {origUrl ? <img src={origUrl} alt="original" className="max-w-xs" /> : <div>No original</div>}
+          {resultUrl ? <img src={resultUrl} alt="result" className="max-w-xs" /> : <div>No result</div>}
+        </div>
+      ) : (
+        <div
+          className="relative inline-block"
+          aria-label="results-display"
+          data-mode="overlay"
+        >
+          {origUrl ? (
+            <img src={origUrl} alt="original" className="max-w-xs block" />
+          ) : (
+            <div>No original</div>
+          )}
+          {resultUrl ? (
+            <img
+              src={resultUrl}
+              alt="result"
+              className="max-w-xs absolute left-0 top-0 opacity-50"
+            />
+          ) : (
+            <div className="absolute left-0 top-0">No result</div>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add overlay mode in `ResultsDisplay` component and toggle button
- update ResultsDisplay tests and ensure cleanup
- handle dict responses in OpenAI service `edit_image`
- fix flake8 issues in integration tests
- update tasks and changelog

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684c8604e9d48331a6540e77e7317e44