### PR TITLE
Implement prompt suggestions and result download

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -152,13 +152,13 @@
 - [x] 5.2 Add prompt length validation and character counter
   - [x] 5.3 Implement recent prompts storage and quick reuse functionality
   - [x] 5.4 Add example prompts and guidance text for new users
-  - [c] 5.5 Include prompt suggestions based on common editing tasks
+  - [x] 5.5 Include prompt suggestions based on common editing tasks
 - [x] 5.6 Create unit tests for prompt input validation and storage
 
 - [ ] 6.0 Build Results Display System (FR15-FR18, US3)
   - [x] 6.1 Create `ResultsDisplay.tsx` component for before/after comparison
   - [x] 6.2 Implement side-by-side and overlay comparison modes
-  - [c] 6.3 Add download/save functionality for edited results
+  - [x] 6.3 Add download/save functionality for edited results
   - [ ] 6.4 Handle display of OpenAI error responses and fallback states
   - [ ] 6.5 Optimize image loading and display performance
   - [x] 6.6 Create unit tests for results display functionality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@
 2025-06-13 Added progress and results display components with tests
 2025-06-13 Added overlay display mode for results and improved OpenAI tests
 2025-06-13 Marked tasks 2.4, 3.6, 5.5, and 6.3 as committed
+2025-06-13 Added prompt suggestions and download link

--- a/frontend/src/components/PromptInput.test.tsx
+++ b/frontend/src/components/PromptInput.test.tsx
@@ -35,4 +35,11 @@ describe('PromptInput', () => {
     expect(localStorage.getItem('recentPrompts')).toContain('hello');
     expect(getByText(/Recent prompts/i)).toBeTruthy();
   });
+
+  it('allows inserting suggestions', () => {
+    const { getByText, getByLabelText } = render(<PromptInput />);
+    fireEvent.click(getByText('Add a watermark'));
+    const textarea = getByLabelText('Prompt') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('Add a watermark');
+  });
 });

--- a/frontend/src/components/PromptInput.tsx
+++ b/frontend/src/components/PromptInput.tsx
@@ -13,6 +13,12 @@ export default function PromptInput({
   const [prompt, setPrompt] = useState('');
   const [error, setError] = useState('');
   const [recent, setRecent] = useState<string[]>([]);
+  const suggestions = [
+    'Remove the background',
+    'Change sky color to blue',
+    'Add a watermark',
+    'Increase brightness',
+  ];
 
   useEffect(() => {
     const stored = localStorage.getItem('recentPrompts');
@@ -98,6 +104,19 @@ export default function PromptInput({
             ))}
           </div>
         )}
+      </div>
+      <div className="text-sm text-gray-600">
+        Suggestions:
+        {suggestions.map((s) => (
+          <button
+            key={s}
+            type="button"
+            className="ml-2 underline"
+            onClick={() => setPrompt(s)}
+          >
+            {s}
+          </button>
+        ))}
       </div>
       <button
         type="submit"

--- a/frontend/src/components/ResultsDisplay.test.tsx
+++ b/frontend/src/components/ResultsDisplay.test.tsx
@@ -27,4 +27,14 @@ describe('ResultsDisplay', () => {
     container = getByLabelText('results-display');
     expect(container.getAttribute('data-mode')).toBe('overlay');
   });
+
+  it('provides a download link for the result', () => {
+    const file = new File(['data'], 'res.png', { type: 'image/png' });
+    const { getByLabelText } = render(
+      <ResultsDisplay original={file} result={file} />
+    );
+    const link = getByLabelText('download-result') as HTMLAnchorElement;
+    expect(link.href).toContain('blob:url');
+    expect(link.getAttribute('download')).toBe('result.png');
+  });
 });

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -33,6 +33,16 @@ export default function ResultsDisplay({ original, result }: Props) {
       >
         {mode === 'side-by-side' ? 'Overlay' : 'Side by Side'}
       </button>
+      {resultUrl && (
+        <a
+          href={resultUrl}
+          download="result.png"
+          className="ml-2 underline"
+          aria-label="download-result"
+        >
+          Download
+        </a>
+      )}
       {mode === 'side-by-side' ? (
         <div className="flex gap-4" aria-label="results-display" data-mode="side-by-side">
           {origUrl ? <img src={origUrl} alt="original" className="max-w-xs" /> : <div>No original</div>}


### PR DESCRIPTION
## Summary
- enable prompt suggestions in PromptInput
- add download link to ResultsDisplay
- test prompt suggestions and result download
- mark tasks 5.5 and 6.3 complete
- document changes in CHANGELOG

## Testing
- `flake8`
- `npm run lint` in `frontend`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684c883242048331b45c1f93ebdc50fe