### PR TITLE
Integrate prompt workflow and error handling

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -159,7 +159,7 @@
   - [x] 6.1 Create `ResultsDisplay.tsx` component for before/after comparison
   - [x] 6.2 Implement side-by-side and overlay comparison modes
   - [x] 6.3 Add download/save functionality for edited results
-  - [ ] 6.4 Handle display of OpenAI error responses and fallback states
+  - [x] 6.4 Handle display of OpenAI error responses and fallback states
   - [ ] 6.5 Optimize image loading and display performance
   - [x] 6.6 Create unit tests for results display functionality
 
@@ -174,8 +174,8 @@
 
 - [ ] 8.0 Frontend-Backend Integration for Complete Workflow (FR1-FR22, US1-US7)
   - [x] 8.1 Update `frontend/src/services/apiClient.ts` with OpenAI integration functions
-  - [ ] 8.2 Connect `PromptInput.tsx` to validation and submission workflow
-  - [ ] 8.3 Integrate enhanced `CanvasDisplay.tsx` with mask export for API submission
+  - [x] 8.2 Connect `PromptInput.tsx` to validation and submission workflow
+  - [x] 8.3 Integrate enhanced `CanvasDisplay.tsx` with mask export for API submission
   - [ ] 8.4 Connect `ResultsDisplay.tsx` to receive and display API responses
   - [ ] 8.5 Implement complete edit workflow in `HomePage.tsx`
   - [ ] 8.6 Add proper loading states and error handling throughout the UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@
 2025-06-13 Added overlay display mode for results and improved OpenAI tests
 2025-06-13 Marked tasks 2.4, 3.6, 5.5, and 6.3 as committed
 2025-06-13 Added prompt suggestions and download link
+2025-06-13 Integrated prompt input with canvas and added error display

--- a/frontend/src/components/CanvasDisplay.test.tsx
+++ b/frontend/src/components/CanvasDisplay.test.tsx
@@ -45,7 +45,7 @@ global.URL.revokeObjectURL = vi.fn();
 describe('CanvasDisplay', () => {
   it('toggles mask visibility and submits', async () => {
     const file = new File(['data'], 'test.png', { type: 'image/png' });
-    const { getByText } = render(<CanvasDisplay image={file} />);
+    const { getByText } = render(<CanvasDisplay image={file} prompt="edit" />);
     await waitFor(() => getByText('Switch to Erase'));
     const toggle = getByText('Hide Mask');
     fireEvent.click(toggle);
@@ -56,7 +56,7 @@ describe('CanvasDisplay', () => {
 
   it('changes brush size using toolbar', async () => {
     const file = new File(['data'], 'test.png', { type: 'image/png' });
-    const { getByLabelText } = render(<CanvasDisplay image={file} />);
+    const { getByLabelText } = render(<CanvasDisplay image={file} prompt="edit" />);
     await waitFor(() => getByLabelText('Large'));
     const large = getByLabelText('Large') as HTMLInputElement;
     fireEvent.click(large);
@@ -65,7 +65,7 @@ describe('CanvasDisplay', () => {
 
   it('clears the mask canvas', async () => {
     const file = new File(['data'], 'test.png', { type: 'image/png' });
-    const { getByText } = render(<CanvasDisplay image={file} />);
+    const { getByText } = render(<CanvasDisplay image={file} prompt="edit" />);
     await waitFor(() => getByText('Clear Mask'));
     const clearBtn = getByText('Clear Mask');
     fireEvent.click(clearBtn);

--- a/frontend/src/components/CanvasDisplay.tsx
+++ b/frontend/src/components/CanvasDisplay.tsx
@@ -9,7 +9,13 @@ import { editImage } from '../services/apiClient';
  * @param image The image file to render, or null if none uploaded.
  */
 
-export default function CanvasDisplay({ image }: { image: File | null }) {
+export default function CanvasDisplay({
+  image,
+  prompt,
+}: {
+  image: File | null;
+  prompt: string;
+}) {
   const baseRef = useRef<HTMLCanvasElement>(null);
   const {
     canvasRef: maskRef,
@@ -79,7 +85,7 @@ export default function CanvasDisplay({ image }: { image: File | null }) {
       const imageFile = imgBlob
         ? new File([imgBlob], 'image.png', { type: 'image/png' })
         : image;
-      const result = await editImage(imageFile, 'Edit', maskFile);
+      const result = await editImage(imageFile, prompt || 'Edit', maskFile);
       setSubmitMsg(result.detail || 'Processing complete');
     } catch (err) {
       setSubmitError((err as Error).message);

--- a/frontend/src/components/ResultsDisplay.test.tsx
+++ b/frontend/src/components/ResultsDisplay.test.tsx
@@ -15,6 +15,13 @@ describe('ResultsDisplay', () => {
     expect(getByText('No result')).toBeTruthy();
   });
 
+  it('displays error message when provided', () => {
+    const { getByText } = render(
+      <ResultsDisplay original={null} result={null} error="oops" />,
+    );
+    expect(getByText('Error: oops')).toBeTruthy();
+  });
+
   it('renders provided images', () => {
     const file = new File(['data'], 'orig.png', { type: 'image/png' });
     const { getAllByRole, getByText, getByLabelText } = render(

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -3,12 +3,13 @@ import React, { useState } from 'react';
 interface Props {
   original: string | File | null;
   result: string | File | null;
+  error?: string;
 }
 
 /**
  * Displays before and after images side by side.
  */
-export default function ResultsDisplay({ original, result }: Props) {
+export default function ResultsDisplay({ original, result, error }: Props) {
   const [mode, setMode] = useState<'side-by-side' | 'overlay'>('side-by-side');
   const origUrl =
     typeof original === 'string'
@@ -46,7 +47,13 @@ export default function ResultsDisplay({ original, result }: Props) {
       {mode === 'side-by-side' ? (
         <div className="flex gap-4" aria-label="results-display" data-mode="side-by-side">
           {origUrl ? <img src={origUrl} alt="original" className="max-w-xs" /> : <div>No original</div>}
-          {resultUrl ? <img src={resultUrl} alt="result" className="max-w-xs" /> : <div>No result</div>}
+          {resultUrl ? (
+            <img src={resultUrl} alt="result" className="max-w-xs" />
+          ) : error ? (
+            <div className="text-red-600">Error: {error}</div>
+          ) : (
+            <div>No result</div>
+          )}
         </div>
       ) : (
         <div
@@ -65,6 +72,8 @@ export default function ResultsDisplay({ original, result }: Props) {
               alt="result"
               className="max-w-xs absolute left-0 top-0 opacity-50"
             />
+          ) : error ? (
+            <div className="absolute left-0 top-0 text-red-600">Error: {error}</div>
           ) : (
             <div className="absolute left-0 top-0">No result</div>
           )}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,9 +2,12 @@ import { useState } from 'react';
 import HealthCheckDisplay from '../components/HealthCheckDisplay';
 import FileUpload from '../components/FileUpload';
 import CanvasDisplay from '../components/CanvasDisplay';
+import PromptInput from '../components/PromptInput';
 
 export default function HomePage() {
   const [image, setImage] = useState<File | null>(null);
+  const [prompt, setPrompt] = useState('');
+  const handlePrompt = (p: string) => setPrompt(p);
   return (
     <div>
       <h1>Welcome to Shiny Broccoli</h1>
@@ -12,7 +15,8 @@ export default function HomePage() {
       <div className="my-4">
         <FileUpload onUploaded={setImage} />
       </div>
-      <CanvasDisplay image={image} />
+      <PromptInput onSubmit={handlePrompt} />
+      <CanvasDisplay image={image} prompt={prompt} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- task updates for prompt workflow and error display
- show API errors in `ResultsDisplay`
- pass prompt to `CanvasDisplay`
- wire `PromptInput` into `HomePage`
- update tests

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684c8b3119ec8331b34a19e491a8c450