### PR TITLE
Implement OpenAI error mapping

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -123,7 +123,7 @@
   - [x] 2.1 Implement image editing function in `openai_service.py` using OpenAI SDK
   - [x] 2.2 Add proper image format conversion (canvas to PNG) for OpenAI compatibility
   - [x] 2.3 Handle OpenAI API responses including success, error, and timeout scenarios
-  - [c] 2.4 Implement request/response validation and error mapping
+  - [x] 2.4 Implement request/response validation and error mapping
   - [x] 2.5 Add comprehensive unit tests for OpenAI service functions
   - [ ] 2.6 Test integration with various image sizes and mask complexities
 
@@ -133,7 +133,7 @@
   - [x] 3.3 Implement `GET /api/v1/images/status/{request_id}` for progress tracking
   - [x] 3.4 Add proper request validation for image, mask, and prompt data
   - [ ] 3.5 Implement async processing for long-running OpenAI requests
-  - [c] 3.6 Add comprehensive error handling and status code mapping
+  - [x] 3.6 Add comprehensive error handling and status code mapping
   - [x] 3.7 Include the new OpenAI router in `backend/app/main.py`
   - [x] 3.8 Create unit tests for all OpenAI integration endpoints
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@
 2025-06-13 Integrated prompt input with canvas and added error display
 2025-06-16 Documented Phase 2 implementation summary
 2025-06-13 Connected results display to API workflow
+2025-06-13 Added OpenAI error mapping for edit endpoint

--- a/backend/app/api/v1/endpoints/openai_integration.py
+++ b/backend/app/api/v1/endpoints/openai_integration.py
@@ -6,6 +6,7 @@ import logging
 import time
 
 from fastapi import APIRouter, UploadFile, File, Form, HTTPException, status
+import openai
 
 from backend.services.openai_service import OpenAIService
 
@@ -48,6 +49,45 @@ async def edit_image(
         img_bytes = await image.read()
         mask_bytes = await mask.read() if mask else None
         result = await service.edit_image(img_bytes, mask_bytes, prompt)
+    except openai.BadRequestError as exc:  # pragma: no cover - network
+        logger.warning("OpenAI bad request: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )
+    except (
+        openai.AuthenticationError,
+        openai.PermissionDeniedError,
+    ) as exc:  # pragma: no cover - network
+        logger.warning("OpenAI auth error: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(exc),
+        )
+    except openai.RateLimitError as exc:  # pragma: no cover - network
+        logger.warning("OpenAI rate limit: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(exc),
+        )
+    except openai.APIConnectionError as exc:  # pragma: no cover - network
+        logger.warning("OpenAI connection error: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        )
+    except openai.APITimeoutError as exc:  # pragma: no cover - network
+        logger.warning("OpenAI timeout: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail=str(exc),
+        )
+    except openai.APIError as exc:  # pragma: no cover - network
+        logger.warning("OpenAI API error: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        )
     except Exception as exc:  # pragma: no cover - should not occur in tests
         logger.exception("OpenAI edit failed")
         raise HTTPException(

--- a/backend/tests/unit/api/v1/test_openai_integration.py
+++ b/backend/tests/unit/api/v1/test_openai_integration.py
@@ -1,5 +1,8 @@
 import io
 from backend.app.api.v1.endpoints import openai_integration
+import httpx
+import openai
+import pytest
 
 
 class DummyService:
@@ -12,6 +15,14 @@ class DummyService:
 
 def patch_service(monkeypatch):
     monkeypatch.setattr(openai_integration, "OpenAIService", lambda: DummyService())
+
+
+def make_error(error_cls, status_code=400):
+    request = httpx.Request("POST", "https://example.com")
+    if issubclass(error_cls, openai.APIConnectionError):
+        return error_cls(message="boom", request=request)
+    response = httpx.Response(status_code, request=request)
+    return error_cls("boom", response=response, body=None)
 
 
 def test_edit_image(client, monkeypatch):
@@ -67,3 +78,26 @@ def test_get_status(client):
     response = client.get("/api/v1/images/status/abc123")
     assert response.status_code == 200
     assert response.json() == {"request_id": "abc123", "status": "pending"}
+
+
+@pytest.mark.parametrize(
+    "error_cls,status",
+    [
+        (openai.BadRequestError, 400),
+        (openai.RateLimitError, 429),
+        (openai.APIConnectionError, 502),
+    ],
+)
+def test_openai_error_mapping(client, monkeypatch, error_cls, status):
+    class FailService:
+        async def edit_image(self, image: bytes, mask: bytes | None, prompt: str):
+            raise make_error(error_cls)
+
+    monkeypatch.setattr(openai_integration, "OpenAIService", lambda: FailService())
+    file_content = io.BytesIO(b"data")
+    response = client.post(
+        "/api/v1/images/edit",
+        files={"image": ("test.png", file_content, "image/png")},
+        data={"prompt": "edit"},
+    )
+    assert response.status_code == status


### PR DESCRIPTION
## Summary
- map OpenAI SDK errors to HTTP status codes
- test error mapping for OpenAI integration endpoints
- mark tasks 2.4 and 3.6 complete
- document update in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684c9207106c8331b7808f55dfdc3c33