### PR TITLE
Implement fetch retry logic

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -77,6 +77,7 @@
 - `frontend/src/components/ProgressIndicator.test.tsx` - Unit tests for `ProgressIndicator` component.
 - `frontend/src/components/ErrorBoundary.tsx` - Error handling and recovery component.
 - `frontend/src/components/ErrorBoundary.test.tsx` - Unit tests for `ErrorBoundary` component.
+- `frontend/src/services/apiClient.test.ts` - Unit tests for API client retry logic.
 - `backend/app/api/v1/endpoints/openai_integration.py` - OpenAI API integration endpoints.
 - `backend/services/openai_service.py` - Service for handling OpenAI API calls.
 - `backend/app/logging.py` - Logging configuration utilities.
@@ -147,7 +148,7 @@
   - [x] 4.7 Update `CanvasDisplay.tsx` to integrate with new toolbar and tools
   - [ ] 4.8 Create comprehensive unit tests for enhanced mask functionality
 
-- [ ] 5.0 Implement Prompt Engineering Interface (FR11-FR14, US1, US4)
+- [x] 5.0 Implement Prompt Engineering Interface (FR11-FR14, US1, US4)
 - [x] 5.1 Create `PromptInput.tsx` component with text area and validation
 - [x] 5.2 Add prompt length validation and character counter
   - [x] 5.3 Implement recent prompts storage and quick reuse functionality
@@ -168,7 +169,7 @@
   - [ ] 7.2 Implement progress tracking for long-running API requests
   - [ ] 7.3 Add estimated completion time display
   - [x] 7.4 Create `ErrorBoundary.tsx` for graceful error recovery
-  - [ ] 7.5 Implement retry functionality for failed requests
+  - [x] 7.5 Implement retry functionality for failed requests
   - [ ] 7.6 Add user-friendly error messages for different failure scenarios
   - [x] 7.7 Create unit tests for progress and error handling components
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@
 2025-06-16 Documented Phase 2 implementation summary
 2025-06-13 Connected results display to API workflow
 2025-06-13 Added OpenAI error mapping for edit endpoint
+2025-06-13 Added retry logic to api client with tests

--- a/frontend/src/services/apiClient.test.ts
+++ b/frontend/src/services/apiClient.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchWithRetry } from './apiClient';
+
+const responseData = { status: 'ok' };
+
+describe('fetchWithRetry', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllTimers();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it('retries failed requests and eventually succeeds', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue(
+        new Response(JSON.stringify(responseData), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    global.fetch = mockFetch as unknown as typeof fetch;
+    const result = await (await fetchWithRetry('url', {}, 2, 0)).json();
+    expect(result).toEqual(responseData);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exhausting retries', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('fail'));
+    global.fetch = mockFetch as unknown as typeof fetch;
+    await expect(fetchWithRetry('url', {}, 2, 0)).rejects.toThrow('fail');
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+});

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -1,8 +1,30 @@
 export const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api/v1';
 
+export async function fetchWithRetry(
+  input: RequestInfo,
+  init?: RequestInit,
+  retries = 2,
+  backoff = 300,
+) {
+  try {
+    const res = await fetch(input, init);
+    if (!res.ok && res.status >= 500 && retries > 0) {
+      await new Promise((r) => setTimeout(r, backoff));
+      return fetchWithRetry(input, init, retries - 1, backoff * 2);
+    }
+    return res;
+  } catch (err) {
+    if (retries > 0) {
+      await new Promise((r) => setTimeout(r, backoff));
+      return fetchWithRetry(input, init, retries - 1, backoff * 2);
+    }
+    throw err;
+  }
+}
+
 export async function fetchHealth() {
-  const response = await fetch(`${API_BASE_URL}/health`);
+  const response = await fetchWithRetry(`${API_BASE_URL}/health`);
   if (!response.ok) {
     throw new Error('Network response was not ok');
   }
@@ -12,7 +34,7 @@ export async function fetchHealth() {
 export async function uploadImage(file: File) {
   const body = new FormData();
   body.append('file', file);
-  const response = await fetch(`${API_BASE_URL}/images/upload`, {
+  const response = await fetchWithRetry(`${API_BASE_URL}/images/upload`, {
     method: 'POST',
     body,
   });
@@ -26,7 +48,7 @@ export async function processImage(file: File, mask?: File) {
   const body = new FormData();
   body.append('file', file);
   if (mask) body.append('mask', mask);
-  const response = await fetch(`${API_BASE_URL}/images/process`, {
+  const response = await fetchWithRetry(`${API_BASE_URL}/images/process`, {
     method: 'POST',
     body,
   });
@@ -45,7 +67,7 @@ export async function editImage(
   body.append('image', image);
   body.append('prompt', prompt);
   if (mask) body.append('mask', mask);
-  const response = await fetch(`${API_BASE_URL}/images/edit`, {
+  const response = await fetchWithRetry(`${API_BASE_URL}/images/edit`, {
     method: 'POST',
     body,
   });
@@ -56,7 +78,9 @@ export async function editImage(
 }
 
 export async function fetchEditStatus(requestId: string) {
-  const response = await fetch(`${API_BASE_URL}/images/status/${requestId}`);
+  const response = await fetchWithRetry(
+    `${API_BASE_URL}/images/status/${requestId}`,
+  );
   if (!response.ok) {
     throw new Error('Failed to fetch status');
   }


### PR DESCRIPTION
## Summary
- mark prompt engineering interface complete and add commit to retry task
- implement `fetchWithRetry` in `apiClient` and export it
- use retry helper in API calls and add unit tests
- document retry logic in tasks and changelog

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684c937a04d88331991d1f60016764c5