### PR TITLE
Add image validation tests

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -91,6 +91,7 @@
 - `frontend/src/pages/HomePage.tsx` - Integration of new components into complete workflow.
 - `frontend/src/services/apiClient.ts` - Added functions for OpenAI integration endpoints.
 - `frontend/src/components/FileUpload.tsx` - Handles image uploads with validation and progress.
+- `frontend/src/components/FileUpload.test.tsx` - Unit tests for image upload validation.
 - `frontend/src/components/HealthCheckDisplay.tsx` - Displays backend health status.
 - `frontend/src/components/MaskToolbar.tsx` - Toolbar for selecting mask brush size.
 - `backend/app/main.py` - Include new OpenAI integration router.
@@ -189,7 +190,7 @@
 - [ ] 9.0 Performance Optimization and Polish (SM1-SM7)
   - [ ] 9.1 Optimize canvas operations for smooth mask drawing performance
   - [ ] 9.2 Implement image compression for large uploads to meet OpenAI size limits
-  - [ ] 9.3 Add client-side validation for image dimensions and format compatibility
+  - [x] 9.3 Add client-side validation for image dimensions and format compatibility
   - [ ] 9.4 Optimize memory usage for large images and long editing sessions
   - [ ] 9.5 Test performance across different browsers and devices
   - [ ] 9.6 Add performance monitoring and logging for optimization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@
 2025-06-13 Added OpenAI error mapping for edit endpoint
 2025-06-13 Added retry logic to api client with tests
 2025-06-13 Added progress indicators and user-friendly errors
+2025-06-13 Added client-side validation tests for image uploads

--- a/frontend/src/components/FileUpload.test.tsx
+++ b/frontend/src/components/FileUpload.test.tsx
@@ -45,4 +45,37 @@ describe('FileUpload', () => {
     await waitFor(() => expect(onUploaded).toHaveBeenCalledWith(file));
     expect(getByText('Upload successful')).toBeTruthy();
   });
+
+  it('rejects unsupported file type', async () => {
+    const { getByLabelText, getByText } = render(<FileUpload />);
+    const input = getByLabelText('Image:');
+    const file = new File(['data'], 'test.bmp', { type: 'image/bmp' });
+    await fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => {
+      expect(getByText('Error: Unsupported file type')).toBeTruthy();
+    });
+  });
+
+  it('rejects images with invalid dimensions', async () => {
+    class InvalidImage {
+      onload: () => void = () => {};
+      onerror: () => void = () => {};
+      width = 300;
+      height = 200;
+      set src(_val: string) { this.onload(); }
+    }
+    // @ts-ignore
+    global.Image = InvalidImage;
+
+    const { getByLabelText, getByText } = render(<FileUpload />);
+    const input = getByLabelText('Image:');
+    const file = new File(['data'], 'bad.png', { type: 'image/png' });
+    await fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => {
+      expect(getByText(/Invalid dimensions/)).toBeTruthy();
+    });
+    // Restore default
+    // @ts-ignore
+    global.Image = RealImage;
+  });
 });


### PR DESCRIPTION
## Summary
- commit to finishing client-side image validation
- add FileUpload validation tests for bad file types and invalid dimensions
- record task completion in task list
- document change in CHANGELOG

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684c9ab0ad588331a105c441a441a554