### PR TITLE
TaskMaster Update: add tests for image size handling

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -82,7 +82,7 @@
 - `backend/services/openai_service.py` - Service for handling OpenAI API calls.
 - `backend/app/logging.py` - Logging configuration utilities.
 - `backend/tests/api/v1/test_openai_integration.py` - Unit tests for OpenAI integration endpoints.
-- `backend/tests/services/test_openai_service.py` - Unit tests for OpenAI service.
+- `backend/tests/unit/services/test_openai_service.py` - Unit tests for OpenAI service.
 
 ### Existing Files Modified
 - `frontend/src/components/CanvasDisplay.tsx` - Enhanced with advanced mask tools and export functionality.
@@ -106,7 +106,7 @@
 - `CHANGELOG.md` - Document Phase 2 implementation progress.
 - `frontend/src/components/CanvasDisplay.test.tsx` - Unit tests for CanvasDisplay component.
 - `backend/tests/api/v1/test_openai_integration.py` - Unit tests for OpenAI integration endpoints.
-- `backend/tests/services/test_openai_service.py` - Unit tests for OpenAI service.
+- `backend/tests/unit/services/test_openai_service.py` - Unit tests for OpenAI service.
 
 ### Notes
 - OpenAI API key must be stored securely in environment variables
@@ -125,13 +125,13 @@
   - [x] 1.5 Create unit tests for OpenAI service configuration and connection
   - [x] 1.6 Update environment setup documentation for API key requirements
 
-- [ ] 2.0 Implement Core OpenAI Image Editing Integration (FR1, FR2, FR3)
+- [x] 2.0 Implement Core OpenAI Image Editing Integration (FR1, FR2, FR3)
   - [x] 2.1 Implement image editing function in `openai_service.py` using OpenAI SDK
   - [x] 2.2 Add proper image format conversion (canvas to PNG) for OpenAI compatibility
   - [x] 2.3 Handle OpenAI API responses including success, error, and timeout scenarios
   - [x] 2.4 Implement request/response validation and error mapping
   - [x] 2.5 Add comprehensive unit tests for OpenAI service functions
-  - [ ] 2.6 Test integration with various image sizes and mask complexities
+  - [x] 2.6 Test integration with various image sizes and mask complexities
 
 - [ ] 3.0 Create OpenAI API Endpoints (FR1-FR5, US5, US7)
   - [x] 3.1 Create `backend/app/api/v1/endpoints/openai_integration.py`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@
 2025-06-13 Added retry logic to api client with tests
 2025-06-13 Added progress indicators and user-friendly errors
 2025-06-13 Added client-side validation tests for image uploads
+2025-06-13 Added tests for image size handling

--- a/backend/tests/unit/services/test_openai_service.py
+++ b/backend/tests/unit/services/test_openai_service.py
@@ -3,6 +3,8 @@ import sys
 import types
 import pytest
 import base64
+from io import BytesIO
+from PIL import Image
 
 
 class DummyModels:
@@ -60,7 +62,7 @@ def test_missing_key(monkeypatch):
 
 
 @pytest.mark.asyncio
-def test_edit_image(monkeypatch):
+async def test_edit_image(monkeypatch):
     # Minimal valid 1x1 PNG image (transparent)
     png_base64 = (
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+"
@@ -68,15 +70,84 @@ def test_edit_image(monkeypatch):
     )
     png_bytes = base64.b64decode(png_base64)
 
-    def factory(api_key: str) -> DummyClient:
+    def factory(api_key=None, **_):
         return DummyClient(api_key)
 
     service_module = load_service(monkeypatch, factory)
     service = service_module.OpenAIService(api_key="test-key")
-    # Use valid PNG bytes
-    result = service.edit_image(png_bytes, None, "prompt")
-    # If edit_image is async, await it
-    if hasattr(result, "__await__"):
-        import asyncio
-        result = asyncio.get_event_loop().run_until_complete(result)
+    result = await service.edit_image(png_bytes, None, "prompt")
     assert isinstance(result, dict)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "img_size,expected",
+    [
+        (100, 256),
+        (400, 512),
+        (800, 1024),
+    ],
+)
+async def test_edit_image_resizes_image(monkeypatch, img_size, expected):
+    buf = BytesIO()
+    Image.new("RGBA", (img_size, img_size)).save(buf, format="PNG")
+    img_bytes = buf.getvalue()
+
+    captured = {}
+
+    class TrackImages:
+        async def edit(self, **kwargs):
+            captured["size"] = kwargs["size"]
+            captured["img"] = Image.open(kwargs["image"]).size
+            return {"ok": True}
+
+    class TrackClient(DummyClient):
+        def __init__(self, key: str | None) -> None:
+            super().__init__(key)
+            self.images = TrackImages()
+
+    def factory(api_key=None, **_):
+        return TrackClient(api_key)
+
+    service_module = load_service(monkeypatch, factory)
+    service = service_module.OpenAIService(api_key="key")
+    result = await service.edit_image(img_bytes, None, "prompt")
+    assert result == {"ok": True}
+    assert captured["size"] == f"{expected}x{expected}"
+    assert captured["img"] == (expected, expected)
+
+
+@pytest.mark.asyncio
+async def test_edit_image_resizes_mask(monkeypatch):
+    img_buf = BytesIO()
+    Image.new("RGBA", (300, 300)).save(img_buf, format="PNG")
+    img_bytes = img_buf.getvalue()
+
+    mask_buf = BytesIO()
+    Image.new("L", (100, 100), color=255).save(mask_buf, format="PNG")
+    mask_bytes = mask_buf.getvalue()
+
+    captured = {}
+
+    class TrackImages:
+        async def edit(self, **kwargs):
+            captured["size"] = kwargs["size"]
+            captured["img"] = Image.open(kwargs["image"]).size
+            captured["mask"] = Image.open(kwargs["mask"]).size
+            return {"ok": True}
+
+    class TrackClient(DummyClient):
+        def __init__(self, key: str | None) -> None:
+            super().__init__(key)
+            self.images = TrackImages()
+
+    def factory(api_key=None, **_):
+        return TrackClient(api_key)
+
+    service_module = load_service(monkeypatch, factory)
+    service = service_module.OpenAIService(api_key="key")
+    result = await service.edit_image(img_bytes, mask_bytes, "prompt")
+    assert result == {"ok": True}
+    assert captured["size"] == "512x512"
+    assert captured["img"] == (512, 512)
+    assert captured["mask"] == (512, 512)


### PR DESCRIPTION
## Summary
- implement image size and mask resize tests
- update task tracking for image size tests
- update changelog

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684c9e4d24e48331b6727f0da427b5a7