### PR TITLE
Implement optimized image loading

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -166,7 +166,7 @@
   - [x] 6.2 Implement side-by-side and overlay comparison modes
   - [x] 6.3 Add download/save functionality for edited results
   - [x] 6.4 Handle display of OpenAI error responses and fallback states
-  - [ ] 6.5 Optimize image loading and display performance
+  - [x] 6.5 Optimize image loading and display performance
   - [x] 6.6 Create unit tests for results display functionality
 
 - [ ] 7.0 Implement Progress and Error Handling (FR19-FR22, US5, US7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@
 2025-06-13 Added progress indicators and user-friendly errors
 2025-06-13 Added client-side validation tests for image uploads
 2025-06-13 Added tests for image size handling
+2025-06-13 Optimized ResultsDisplay image handling and updated tests

--- a/frontend/src/components/ResultsDisplay.test.tsx
+++ b/frontend/src/components/ResultsDisplay.test.tsx
@@ -5,9 +5,11 @@ import ResultsDisplay from './ResultsDisplay';
 describe('ResultsDisplay', () => {
   beforeAll(() => {
     global.URL.createObjectURL = vi.fn(() => 'blob:url');
+    global.URL.revokeObjectURL = vi.fn();
   });
   afterEach(() => {
     cleanup();
+    vi.clearAllMocks();
   });
   it('shows placeholders when no images provided', () => {
     const { getByText } = render(<ResultsDisplay original={null} result={null} />);
@@ -43,5 +45,14 @@ describe('ResultsDisplay', () => {
     const link = getByLabelText('download-result') as HTMLAnchorElement;
     expect(link.href).toContain('blob:url');
     expect(link.getAttribute('download')).toBe('result.png');
+  });
+
+  it('revokes object URLs on unmount', () => {
+    const file = new File(['data'], 'res.png', { type: 'image/png' });
+    const { unmount } = render(
+      <ResultsDisplay original={file} result={file} />
+    );
+    unmount();
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 interface Props {
   original: string | File | null;
@@ -11,18 +11,36 @@ interface Props {
  */
 export default function ResultsDisplay({ original, result, error }: Props) {
   const [mode, setMode] = useState<'side-by-side' | 'overlay'>('side-by-side');
-  const origUrl =
-    typeof original === 'string'
-      ? original
-      : original
-      ? URL.createObjectURL(original)
-      : null;
-  const resultUrl =
-    typeof result === 'string'
-      ? result
-      : result
-      ? URL.createObjectURL(result)
-      : null;
+  const [origUrl, setOrigUrl] = useState<string | null>(
+    typeof original === 'string' ? original : null,
+  );
+  const [resultUrl, setResultUrl] = useState<string | null>(
+    typeof result === 'string' ? result : null,
+  );
+
+  useEffect(() => {
+    if (typeof original === 'string' || !original) {
+      setOrigUrl(original || null);
+      return;
+    }
+    const url = URL.createObjectURL(original);
+    setOrigUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [original]);
+
+  useEffect(() => {
+    if (typeof result === 'string' || !result) {
+      setResultUrl(result || null);
+      return;
+    }
+    const url = URL.createObjectURL(result);
+    setResultUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [result]);
   return (
     <div>
       <button
@@ -46,9 +64,13 @@ export default function ResultsDisplay({ original, result, error }: Props) {
       )}
       {mode === 'side-by-side' ? (
         <div className="flex gap-4" aria-label="results-display" data-mode="side-by-side">
-          {origUrl ? <img src={origUrl} alt="original" className="max-w-xs" /> : <div>No original</div>}
+          {origUrl ? (
+            <img src={origUrl} alt="original" className="max-w-xs" loading="lazy" />
+          ) : (
+            <div>No original</div>
+          )}
           {resultUrl ? (
-            <img src={resultUrl} alt="result" className="max-w-xs" />
+            <img src={resultUrl} alt="result" className="max-w-xs" loading="lazy" />
           ) : error ? (
             <div className="text-red-600">Error: {error}</div>
           ) : (
@@ -62,7 +84,7 @@ export default function ResultsDisplay({ original, result, error }: Props) {
           data-mode="overlay"
         >
           {origUrl ? (
-            <img src={origUrl} alt="original" className="max-w-xs block" />
+            <img src={origUrl} alt="original" className="max-w-xs block" loading="lazy" />
           ) : (
             <div>No original</div>
           )}
@@ -71,6 +93,7 @@ export default function ResultsDisplay({ original, result, error }: Props) {
               src={resultUrl}
               alt="result"
               className="max-w-xs absolute left-0 top-0 opacity-50"
+              loading="lazy"
             />
           ) : error ? (
             <div className="absolute left-0 top-0 text-red-600">Error: {error}</div>


### PR DESCRIPTION
## Summary
- release object URLs in `ResultsDisplay` and lazy-load images
- test URL revocation behaviour
- update tasks
- document changes in CHANGELOG

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh -no_integration`


------
https://chatgpt.com/codex/tasks/task_e_684ca7237ca88331bb948d233fe0fbf0