### PR TITLE
Implement rectangle and circle mask tools

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -145,7 +145,7 @@
 
 - [ ] 4.0 Enhance Mask Drawing System (FR6-FR10, US2, US6)
   - [x] 4.1 Create `MaskToolbar.tsx` component with brush size controls (small, medium, large)
-  - [ ] 4.2 Implement rectangle and circle selection tools in addition to freehand drawing
+  - [x] 4.2 Implement rectangle and circle selection tools in addition to freehand drawing
   - [x] 4.3 Add "Clear Mask" functionality to reset the entire mask
   - [ ] 4.4 Implement undo/redo system for mask operations
   - [x] 4.5 Enhance `useCanvas.ts` hook with advanced drawing state management
@@ -161,7 +161,7 @@
   - [x] 5.5 Include prompt suggestions based on common editing tasks
 - [x] 5.6 Create unit tests for prompt input validation and storage
 
-- [ ] 6.0 Build Results Display System (FR15-FR18, US3)
+- [x] 6.0 Build Results Display System (FR15-FR18, US3)
   - [x] 6.1 Create `ResultsDisplay.tsx` component for before/after comparison
   - [x] 6.2 Implement side-by-side and overlay comparison modes
   - [x] 6.3 Add download/save functionality for edited results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@
 2025-06-13 Added client-side validation tests for image uploads
 2025-06-13 Added tests for image size handling
 2025-06-13 Optimized ResultsDisplay image handling and updated tests
+2025-06-13 Added rectangle and circle mask drawing tools

--- a/frontend/src/components/CanvasDisplay.test.tsx
+++ b/frontend/src/components/CanvasDisplay.test.tsx
@@ -63,6 +63,15 @@ describe('CanvasDisplay', () => {
     expect(large.checked).toBe(true);
   });
 
+  it('changes drawing tool using toolbar', async () => {
+    const file = new File(['data'], 'test.png', { type: 'image/png' });
+    const { getByLabelText } = render(<CanvasDisplay image={file} prompt="edit" />);
+    await waitFor(() => getByLabelText('rectangle'));
+    const rect = getByLabelText('rectangle') as HTMLInputElement;
+    fireEvent.click(rect);
+    expect(rect.checked).toBe(true);
+  });
+
   it('clears the mask canvas', async () => {
     const file = new File(['data'], 'test.png', { type: 'image/png' });
     const { getByText } = render(<CanvasDisplay image={file} prompt="edit" />);

--- a/frontend/src/components/CanvasDisplay.tsx
+++ b/frontend/src/components/CanvasDisplay.tsx
@@ -26,6 +26,8 @@ export default function CanvasDisplay({ image, prompt, onResult, onError }: Prop
     clear,
     brushSize,
     setBrushSize,
+    tool,
+    setTool,
   } = useCanvas();
   const [maskVisible, setMaskVisible] = useState(true);
   const [submitMsg, setSubmitMsg] = useState('');
@@ -104,7 +106,12 @@ export default function CanvasDisplay({ image, prompt, onResult, onError }: Prop
       {image ? (
         <>
           <div className="mb-2 flex items-center gap-2">
-            <MaskToolbar brushSize={brushSize} setBrushSize={setBrushSize} />
+            <MaskToolbar
+              brushSize={brushSize}
+              setBrushSize={setBrushSize}
+              tool={tool}
+              setTool={setTool}
+            />
             <button
               type="button"
               onClick={toggleMode}
@@ -127,6 +134,7 @@ export default function CanvasDisplay({ image, prompt, onResult, onError }: Prop
               Clear Mask
             </button>
             <span className="text-sm text-gray-600">Mode: {mode}</span>
+            <span className="text-sm text-gray-600">Tool: {tool}</span>
           </div>
           <div className="relative inline-block">
             <canvas ref={baseRef} className="border block" />

--- a/frontend/src/components/MaskToolbar.test.tsx
+++ b/frontend/src/components/MaskToolbar.test.tsx
@@ -6,10 +6,21 @@ describe('MaskToolbar', () => {
   it('changes brush size', () => {
     const setSize = vi.fn();
     const { getByLabelText } = render(
-      <MaskToolbar brushSize="medium" setBrushSize={setSize} />
+      <MaskToolbar brushSize="medium" setBrushSize={setSize} tool="brush" setTool={vi.fn()} />
     );
     const large = getByLabelText('Large');
     fireEvent.click(large);
     expect(setSize).toHaveBeenCalledWith('large');
+  });
+
+  it('changes drawing tool', () => {
+    const setTool = vi.fn();
+    const { getAllByLabelText } = render(
+      <MaskToolbar brushSize="medium" setBrushSize={vi.fn()} tool="brush" setTool={setTool} />
+    );
+    const rects = getAllByLabelText('rectangle');
+    const rect = rects[rects.length - 1];
+    fireEvent.click(rect);
+    expect(setTool).toHaveBeenCalledWith('rectangle');
   });
 });

--- a/frontend/src/components/MaskToolbar.tsx
+++ b/frontend/src/components/MaskToolbar.tsx
@@ -5,30 +5,51 @@ import React from 'react';
  */
 
 export type BrushSize = 'small' | 'medium' | 'large';
+export type Tool = 'brush' | 'rectangle' | 'circle';
 
 interface Props {
   brushSize: BrushSize;
   setBrushSize: (size: BrushSize) => void;
+  tool: Tool;
+  setTool: (tool: Tool) => void;
 }
 
-export default function MaskToolbar({ brushSize, setBrushSize }: Props) {
+export default function MaskToolbar({ brushSize, setBrushSize, tool, setTool }: Props) {
   const options: BrushSize[] = ['small', 'medium', 'large'];
+  const toolOptions: Tool[] = ['brush', 'rectangle', 'circle'];
   const label = (s: BrushSize) => s.charAt(0).toUpperCase() + s.slice(1);
   return (
-    <div className="flex items-center gap-2" aria-label="Mask Toolbar">
-      {options.map((opt) => (
-        <label key={opt} className="flex items-center gap-1">
-          <input
-            type="radio"
-            aria-label={label(opt)}
-            name="brush-size"
-            value={opt}
-            checked={brushSize === opt}
-            onChange={() => setBrushSize(opt)}
-          />
-          {label(opt)}
-        </label>
-      ))}
+    <div className="flex items-center gap-4" aria-label="Mask Toolbar">
+      <div className="flex items-center gap-2">
+        {options.map((opt) => (
+          <label key={opt} className="flex items-center gap-1">
+            <input
+              type="radio"
+              aria-label={label(opt)}
+              name="brush-size"
+              value={opt}
+              checked={brushSize === opt}
+              onChange={() => setBrushSize(opt)}
+            />
+            {label(opt)}
+          </label>
+        ))}
+      </div>
+      <div className="flex items-center gap-2">
+        {toolOptions.map((t) => (
+          <label key={t} className="flex items-center gap-1">
+            <input
+              type="radio"
+              aria-label={t}
+              name="draw-tool"
+              value={t}
+              checked={tool === t}
+              onChange={() => setTool(t)}
+            />
+            {t}
+          </label>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/hooks/useCanvas.test.tsx
+++ b/frontend/src/hooks/useCanvas.test.tsx
@@ -31,4 +31,12 @@ describe('useCanvas', () => {
     });
     expect(result.current.brushSize).toBe('large');
   });
+
+  it('updates drawing tool', () => {
+    const { result } = renderHook(() => useCanvas());
+    act(() => {
+      result.current.setTool('rectangle');
+    });
+    expect(result.current.tool).toBe('rectangle');
+  });
 });

--- a/frontend/src/hooks/useCanvas.ts
+++ b/frontend/src/hooks/useCanvas.ts
@@ -5,12 +5,15 @@ import { useRef, useEffect, useState } from 'react';
  * Sets up pointer event handlers to allow freehand drawing.
  */
 export type BrushSize = 'small' | 'medium' | 'large';
+export type Tool = 'brush' | 'rectangle' | 'circle';
 
 export default function useCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const drawing = useRef(false);
+  const startPos = useRef<{ x: number; y: number } | null>(null);
   const [mode, setMode] = useState<'draw' | 'erase'>('draw');
   const [brushSize, setBrushSize] = useState<BrushSize>('medium');
+  const [tool, setTool] = useState<Tool>('brush');
   const toggleMode = () => setMode((m) => (m === 'draw' ? 'erase' : 'draw'));
 
   const fillWhite = (ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement) => {
@@ -39,8 +42,11 @@ export default function useCanvas() {
 
     const startDraw = (e: PointerEvent) => {
       drawing.current = true;
-      ctx.beginPath();
-      ctx.moveTo(e.offsetX, e.offsetY);
+      startPos.current = { x: e.offsetX, y: e.offsetY };
+      if (tool === 'brush') {
+        ctx.beginPath();
+        ctx.moveTo(e.offsetX, e.offsetY);
+      }
       canvas.style.cursor = 'crosshair';
     };
     const draw = (e: PointerEvent) => {
@@ -51,15 +57,34 @@ export default function useCanvas() {
       if (mode === 'draw') {
         ctx.globalCompositeOperation = 'destination-out';
         ctx.strokeStyle = 'black';
+        ctx.fillStyle = 'black';
       } else {
         ctx.globalCompositeOperation = 'source-over';
         ctx.strokeStyle = 'white';
+        ctx.fillStyle = 'white';
       }
-      ctx.lineTo(e.offsetX, e.offsetY);
-      ctx.stroke();
+      if (tool === 'brush') {
+        ctx.lineTo(e.offsetX, e.offsetY);
+        ctx.stroke();
+      }
     };
-    const stopDraw = () => {
+    const stopDraw = (e: PointerEvent) => {
+      if (!drawing.current) return;
       drawing.current = false;
+      const start = startPos.current;
+      startPos.current = null;
+      if (tool === 'rectangle' && start) {
+        const w = e.offsetX - start.x;
+        const h = e.offsetY - start.y;
+        ctx.beginPath();
+        ctx.rect(start.x, start.y, w, h);
+        ctx.fill();
+      } else if (tool === 'circle' && start) {
+        const r = Math.hypot(e.offsetX - start.x, e.offsetY - start.y);
+        ctx.beginPath();
+        ctx.arc(start.x, start.y, r, 0, Math.PI * 2);
+        ctx.fill();
+      }
       canvas.style.cursor = 'default';
     };
 
@@ -74,7 +99,16 @@ export default function useCanvas() {
       canvas.removeEventListener('pointerup', stopDraw);
       canvas.removeEventListener('pointerleave', stopDraw);
     };
-  }, [mode, brushSize]);
+  }, [mode, brushSize, tool]);
 
-  return { canvasRef, mode, toggleMode, clear, brushSize, setBrushSize };
+  return {
+    canvasRef,
+    mode,
+    toggleMode,
+    clear,
+    brushSize,
+    setBrushSize,
+    tool,
+    setTool,
+  };
 }


### PR DESCRIPTION
## Summary
- commit to mask drawing improvement task and mark Results Display done
- add rectangle and circle drawing tools via `useCanvas` hook
- update `MaskToolbar` and `CanvasDisplay` with tool selection UI
- extend unit tests for new functionality
- document changes in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684ca9a60ad88331beccb345ab93c392