### PR TITLE
Implement undo/redo mask operations

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -144,15 +144,15 @@
   - [x] 3.7 Include the new OpenAI router in `backend/app/main.py`
   - [x] 3.8 Create unit tests for all OpenAI integration endpoints
 
-- [ ] 4.0 Enhance Mask Drawing System (FR6-FR10, US2, US6)
+- [x] 4.0 Enhance Mask Drawing System (FR6-FR10, US2, US6)
   - [x] 4.1 Create `MaskToolbar.tsx` component with brush size controls (small, medium, large)
   - [x] 4.2 Implement rectangle and circle selection tools in addition to freehand drawing
   - [x] 4.3 Add "Clear Mask" functionality to reset the entire mask
-  - [ ] 4.4 Implement undo/redo system for mask operations
+  - [x] 4.4 Implement undo/redo system for mask operations
   - [x] 4.5 Enhance `useCanvas.ts` hook with advanced drawing state management
   - [x] 4.6 Add mask export functionality to generate proper PNG data for API
   - [x] 4.7 Update `CanvasDisplay.tsx` to integrate with new toolbar and tools
-  - [ ] 4.8 Create comprehensive unit tests for enhanced mask functionality
+  - [x] 4.8 Create comprehensive unit tests for enhanced mask functionality
 
 - [x] 5.0 Implement Prompt Engineering Interface (FR11-FR14, US1, US4)
 - [x] 5.1 Create `PromptInput.tsx` component with text area and validation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,4 @@
 2025-06-13 Optimized ResultsDisplay image handling and updated tests
 2025-06-13 Added rectangle and circle mask drawing tools
 2025-06-13 Added user guide documentation for editing workflow
+2025-06-13 Added undo/redo mask functionality with tests

--- a/frontend/src/components/CanvasDisplay.test.tsx
+++ b/frontend/src/components/CanvasDisplay.test.tsx
@@ -21,6 +21,8 @@ HTMLCanvasElement.prototype.getContext = vi.fn(function () {
     moveTo: vi.fn(),
     lineTo: vi.fn(),
     stroke: vi.fn(),
+    getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(1) })),
+    putImageData: vi.fn(),
   } as unknown as CanvasRenderingContext2D;
   contexts.push(ctx);
   return ctx;
@@ -80,6 +82,18 @@ describe('CanvasDisplay', () => {
     fireEvent.click(clearBtn);
     const called = contexts.some((ctx) => ctx.fillRect.mock.calls.length > 0);
     expect(called).toBe(true);
+  });
+
+  it('undoes and redoes mask actions', async () => {
+    const file = new File(['data'], 'test.png', { type: 'image/png' });
+    const { getByText } = render(<CanvasDisplay image={file} prompt="edit" />);
+    await waitFor(() => getByText('Clear Mask'));
+    fireEvent.click(getByText('Clear Mask'));
+    await waitFor(() => expect(getByText('Undo').getAttribute('disabled')).toBeNull());
+    fireEvent.click(getByText('Undo'));
+    await waitFor(() => expect(getByText('Redo').getAttribute('disabled')).toBeNull());
+    fireEvent.click(getByText('Redo'));
+    await waitFor(() => expect(getByText('Undo').getAttribute('disabled')).toBeNull());
   });
 
   it('returns the result via callback', async () => {

--- a/frontend/src/components/CanvasDisplay.tsx
+++ b/frontend/src/components/CanvasDisplay.tsx
@@ -24,6 +24,10 @@ export default function CanvasDisplay({ image, prompt, onResult, onError }: Prop
     mode,
     toggleMode,
     clear,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
     brushSize,
     setBrushSize,
     tool,
@@ -132,6 +136,22 @@ export default function CanvasDisplay({ image, prompt, onResult, onError }: Prop
               className="px-2 py-1 border rounded"
             >
               Clear Mask
+            </button>
+            <button
+              type="button"
+              onClick={undo}
+              disabled={!canUndo}
+              className="px-2 py-1 border rounded"
+            >
+              Undo
+            </button>
+            <button
+              type="button"
+              onClick={redo}
+              disabled={!canRedo}
+              className="px-2 py-1 border rounded"
+            >
+              Redo
             </button>
             <span className="text-sm text-gray-600">Mode: {mode}</span>
             <span className="text-sm text-gray-600">Tool: {tool}</span>

--- a/frontend/src/hooks/useCanvas.test.tsx
+++ b/frontend/src/hooks/useCanvas.test.tsx
@@ -16,7 +16,16 @@ describe('useCanvas', () => {
     const { result } = renderHook(() => useCanvas());
     const canvas = document.createElement('canvas');
     const fillRect = vi.fn();
-    canvas.getContext = vi.fn(() => ({ fillRect, globalCompositeOperation: 'source-over', fillStyle: 'white' } as unknown as CanvasRenderingContext2D));
+    canvas.getContext = vi.fn(
+      () =>
+        ({
+          fillRect,
+          getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(1) })),
+          putImageData: vi.fn(),
+          globalCompositeOperation: 'source-over',
+          fillStyle: 'white',
+        } as unknown as CanvasRenderingContext2D),
+    );
     result.current.canvasRef.current = canvas;
     act(() => {
       result.current.clear();
@@ -38,5 +47,39 @@ describe('useCanvas', () => {
       result.current.setTool('rectangle');
     });
     expect(result.current.tool).toBe('rectangle');
+  });
+
+  it('supports undo and redo', () => {
+    const { result } = renderHook(() => useCanvas());
+    const canvas = document.createElement('canvas');
+    canvas.width = 10;
+    canvas.height = 10;
+    const putImageData = vi.fn();
+    const getImageData = vi.fn(() => ({ data: new Uint8ClampedArray(1) }));
+    canvas.getContext = vi.fn(() =>
+      ({
+        fillRect: vi.fn(),
+        getImageData,
+        putImageData,
+        globalCompositeOperation: 'source-over',
+        fillStyle: 'white',
+      } as unknown as CanvasRenderingContext2D),
+    );
+    result.current.canvasRef.current = canvas;
+
+    act(() => {
+      result.current.clear();
+    });
+    expect(result.current.canUndo).toBe(true);
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(putImageData).toHaveBeenCalled();
+
+    act(() => {
+      result.current.redo();
+    });
+    expect(putImageData).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/hooks/useCanvas.ts
+++ b/frontend/src/hooks/useCanvas.ts
@@ -14,6 +14,9 @@ export default function useCanvas() {
   const [mode, setMode] = useState<'draw' | 'erase'>('draw');
   const [brushSize, setBrushSize] = useState<BrushSize>('medium');
   const [tool, setTool] = useState<Tool>('brush');
+  const history = useRef<ImageData[]>([]);
+  const redoStack = useRef<ImageData[]>([]);
+  const [, forceRender] = useState({});
   const toggleMode = () => setMode((m) => (m === 'draw' ? 'erase' : 'draw'));
 
   const fillWhite = (ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement) => {
@@ -27,6 +30,9 @@ export default function useCanvas() {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
+    history.current.push(ctx.getImageData(0, 0, canvas.width, canvas.height));
+    redoStack.current = [];
+    forceRender({});
     fillWhite(ctx, canvas);
   };
 
@@ -43,6 +49,11 @@ export default function useCanvas() {
     const startDraw = (e: PointerEvent) => {
       drawing.current = true;
       startPos.current = { x: e.offsetX, y: e.offsetY };
+      history.current.push(
+        ctx.getImageData(0, 0, canvas.width, canvas.height),
+      );
+      redoStack.current = [];
+      forceRender({});
       if (tool === 'brush') {
         ctx.beginPath();
         ctx.moveTo(e.offsetX, e.offsetY);
@@ -101,6 +112,28 @@ export default function useCanvas() {
     };
   }, [mode, brushSize, tool]);
 
+  const undo = () => {
+    const canvas = canvasRef.current;
+    if (!canvas || history.current.length === 0) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const prev = history.current.pop()!;
+    redoStack.current.push(ctx.getImageData(0, 0, canvas.width, canvas.height));
+    ctx.putImageData(prev, 0, 0);
+    forceRender({});
+  };
+
+  const redo = () => {
+    const canvas = canvasRef.current;
+    if (!canvas || redoStack.current.length === 0) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const next = redoStack.current.pop()!;
+    history.current.push(ctx.getImageData(0, 0, canvas.width, canvas.height));
+    ctx.putImageData(next, 0, 0);
+    forceRender({});
+  };
+
   return {
     canvasRef,
     mode,
@@ -110,5 +143,9 @@ export default function useCanvas() {
     setBrushSize,
     tool,
     setTool,
+    undo,
+    redo,
+    canUndo: history.current.length > 0,
+    canRedo: redoStack.current.length > 0,
   };
 }


### PR DESCRIPTION
## Summary
- add undo/redo state management to useCanvas hook
- expose undo/redo controls in CanvasDisplay
- test undo/redo behavior
- mark mask drawing tasks complete
- document change in CHANGELOG

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh -no_integration`


------
https://chatgpt.com/codex/tasks/task_e_684caf15c8508331a848e3512a18f5ef