### PR TITLE
Add PNG compression to OpenAI service

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -79,7 +79,7 @@
 - `frontend/src/components/ErrorBoundary.test.tsx` - Unit tests for `ErrorBoundary` component.
 - `frontend/src/services/apiClient.test.ts` - Unit tests for API client retry logic.
 - `backend/app/api/v1/endpoints/openai_integration.py` - OpenAI API integration endpoints.
-- `backend/services/openai_service.py` - Service for handling OpenAI API calls.
+- `backend/services/openai_service.py` - Service for handling OpenAI API calls with PNG compression.
 - `backend/app/logging.py` - Logging configuration utilities.
 - `backend/tests/api/v1/test_openai_integration.py` - Unit tests for OpenAI integration endpoints.
 - `backend/tests/unit/services/test_openai_service.py` - Unit tests for OpenAI service.
@@ -97,7 +97,7 @@
 - `frontend/src/components/MaskToolbar.tsx` - Toolbar for selecting mask brush size.
 - `backend/app/main.py` - Include new OpenAI integration router.
 - `backend/app/api/v1/endpoints/openai_integration.py` - OpenAI API integration endpoints.
-- `backend/services/openai_service.py` - Service for handling OpenAI API calls.
+- `backend/services/openai_service.py` - Service for handling OpenAI API calls with PNG compression.
 - `backend/services/chat_storage.py` - In-memory chat message storage.
 - `backend/app/core/config.py` - Add OpenAI API key configuration.
 - `backend/requirements.txt` - Add OpenAI Python SDK and related dependencies.
@@ -190,7 +190,7 @@
 
 - [ ] 9.0 Performance Optimization and Polish (SM1-SM7)
   - [ ] 9.1 Optimize canvas operations for smooth mask drawing performance
-  - [ ] 9.2 Implement image compression for large uploads to meet OpenAI size limits
+  - [x] 9.2 Implement image compression for large uploads to meet OpenAI size limits
   - [x] 9.3 Add client-side validation for image dimensions and format compatibility
   - [ ] 9.4 Optimize memory usage for large images and long editing sessions
   - [ ] 9.5 Test performance across different browsers and devices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@
 2025-06-13 Added rectangle and circle mask drawing tools
 2025-06-13 Added user guide documentation for editing workflow
 2025-06-13 Added undo/redo mask functionality with tests
+2025-06-13 Added PNG compression to OpenAI service

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -1,4 +1,4 @@
-"""OpenAI API client service."""
+"""OpenAI API client service with basic PNG optimization."""
 
 from __future__ import annotations
 
@@ -44,15 +44,13 @@ class OpenAIService:
             return dict(response)
 
     def _ensure_png(self, data: bytes) -> bytes:
-        """Convert image bytes to PNG if not already."""
+        """Return image data encoded as optimized PNG."""
         if Image is None:  # pragma: no cover - Pillow not installed
             return data
         img = Image.open(BytesIO(data))
-        if img.format != "PNG":
-            buf = BytesIO()
-            img.save(buf, format="PNG")
-            return buf.getvalue()
-        return data
+        buf = BytesIO()
+        img.save(buf, format="PNG", optimize=True)
+        return buf.getvalue()
 
     async def edit_image(
         self, image: bytes, mask: bytes | None, prompt: str, n: int = 1
@@ -91,7 +89,7 @@ class OpenAIService:
                     if orig_w != target_size or orig_h != target_size:
                         img_obj = img_obj.resize((target_size, target_size))
                         buf = BytesIO()
-                        img_obj.save(buf, format="PNG")
+                        img_obj.save(buf, format="PNG", optimize=True)
                         png_image = buf.getvalue()
 
                     width = height = target_size
@@ -102,7 +100,7 @@ class OpenAIService:
                         if m_obj.size[0] != target_size or m_obj.size[1] != target_size:
                             m_obj = m_obj.resize((target_size, target_size))
                             mbuf = BytesIO()
-                            m_obj.save(mbuf, format="PNG")
+                            m_obj.save(mbuf, format="PNG", optimize=True)
                             png_mask = mbuf.getvalue()
             else:  # pragma: no cover - Pillow not installed
                 # This case should ideally not happen if frontend validates

--- a/backend/tests/unit/services/test_openai_service.py
+++ b/backend/tests/unit/services/test_openai_service.py
@@ -151,3 +151,20 @@ async def test_edit_image_resizes_mask(monkeypatch):
     assert captured["size"] == "512x512"
     assert captured["img"] == (512, 512)
     assert captured["mask"] == (512, 512)
+
+
+def test_ensure_png_optimizes(monkeypatch):
+    def factory(api_key=None):
+        return DummyClient(api_key)
+
+    service_module = load_service(monkeypatch, factory)
+    service = service_module.OpenAIService(api_key="key")
+
+    buf = BytesIO()
+    Image.new("RGBA", (256, 256), color="red").save(buf, format="PNG", optimize=False)
+    data = buf.getvalue()
+
+    optimized = service._ensure_png(data)
+
+    assert optimized.startswith(b"\x89PNG")
+    assert len(optimized) <= len(data)


### PR DESCRIPTION
## Summary
- compress PNG outputs in `OpenAIService`
- test PNG optimization logic
- update task list for image compression
- document changes in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684cb388e18c833188d3c70ae3999955