### PR TITLE
Implement async image edit processing

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -80,6 +80,7 @@
 - `frontend/src/services/apiClient.test.ts` - Unit tests for API client retry logic.
 - `backend/app/api/v1/endpoints/openai_integration.py` - OpenAI API integration endpoints.
 - `backend/services/openai_service.py` - Service for handling OpenAI API calls with PNG compression.
+- `backend/services/task_manager.py` - Simple in-memory tracker for async request progress.
 - `backend/app/logging.py` - Logging configuration utilities.
 - `backend/tests/api/v1/test_openai_integration.py` - Unit tests for OpenAI integration endpoints.
 - `backend/tests/unit/services/test_openai_service.py` - Unit tests for OpenAI service.
@@ -139,7 +140,7 @@
   - [x] 3.2 Implement `POST /api/v1/images/edit` endpoint for OpenAI image editing
   - [x] 3.3 Implement `GET /api/v1/images/status/{request_id}` for progress tracking
   - [x] 3.4 Add proper request validation for image, mask, and prompt data
-  - [ ] 3.5 Implement async processing for long-running OpenAI requests
+  - [x] 3.5 Implement async processing for long-running OpenAI requests
   - [x] 3.6 Add comprehensive error handling and status code mapping
   - [x] 3.7 Include the new OpenAI router in `backend/app/main.py`
   - [x] 3.8 Create unit tests for all OpenAI integration endpoints
@@ -172,7 +173,7 @@
 
 - [ ] 7.0 Implement Progress and Error Handling (FR19-FR22, US5, US7)
   - [x] 7.1 Create `ProgressIndicator.tsx` component with loading animations
-  - [ ] 7.2 Implement progress tracking for long-running API requests
+  - [x] 7.2 Implement progress tracking for long-running API requests
   - [ ] 7.3 Add estimated completion time display
   - [x] 7.4 Create `ErrorBoundary.tsx` for graceful error recovery
   - [x] 7.5 Implement retry functionality for failed requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,4 @@
 2025-06-13 Added user guide documentation for editing workflow
 2025-06-13 Added undo/redo mask functionality with tests
 2025-06-13 Added PNG compression to OpenAI service
+2025-06-13 Added async processing with progress tracking for image edits

--- a/backend/app/api/v1/endpoints/openai_integration.py
+++ b/backend/app/api/v1/endpoints/openai_integration.py
@@ -5,18 +5,43 @@ from __future__ import annotations
 import logging
 import time
 
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException, status
+from fastapi import (
+    APIRouter,
+    UploadFile,
+    File,
+    Form,
+    HTTPException,
+    status,
+    BackgroundTasks,
+)
 import openai
+from uuid import uuid4
 
 from backend.services.openai_service import OpenAIService
+from backend.services import task_manager
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
+async def _process_request(
+    request_id: str, image: bytes, mask: bytes | None, prompt: str
+) -> None:
+    """Background task to send edit request to OpenAI."""
+    service = OpenAIService()
+    try:
+        result = await service.edit_image(image, mask, prompt)
+    except Exception as exc:  # pragma: no cover - network errors handled in tests
+        logger.exception("OpenAI edit failed")
+        task_manager.set_error(request_id, str(exc))
+    else:
+        task_manager.set_result(request_id, result)
+
+
 @router.post("/images/edit")
 async def edit_image(
+    background_tasks: BackgroundTasks,
     image: UploadFile = File(...),
     mask: UploadFile | None = File(None),
     prompt: str = Form(""),
@@ -44,11 +69,14 @@ async def edit_image(
         )
     start = time.time()
     logger.info("/images/edit called")
-    service = OpenAIService()
     try:
         img_bytes = await image.read()
         mask_bytes = await mask.read() if mask else None
-        result = await service.edit_image(img_bytes, mask_bytes, prompt)
+        request_id = uuid4().hex
+        task_manager.create_task(request_id)
+        background_tasks.add_task(
+            _process_request, request_id, img_bytes, mask_bytes, prompt
+        )
     except openai.BadRequestError as exc:  # pragma: no cover - network
         logger.warning("OpenAI bad request: %s", exc)
         raise HTTPException(
@@ -94,13 +122,23 @@ async def edit_image(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=str(exc),
         )
-    logger.info("/images/edit completed in %.3f", time.time() - start)
-    return result
+    logger.info("/images/edit queued in %.3f", time.time() - start)
+    return {"request_id": request_id}
 
 
 @router.get("/images/status/{request_id}")
-async def get_status(request_id: str) -> dict[str, str]:
+async def get_status(request_id: str) -> dict[str, object]:
     """Return the processing status for an image edit request."""
     logger.info("/images/status called for %s", request_id)
-    # Placeholder implementation until async processing is added
-    return {"request_id": request_id, "status": "pending"}
+    record = task_manager.get_task(request_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="Request not found")
+    response: dict[str, object] = {
+        "request_id": request_id,
+        "status": record.status,
+    }
+    if record.result is not None:
+        response["result"] = record.result
+    if record.error is not None:
+        response["error"] = record.error
+    return response

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -1,0 +1,41 @@
+"""Simple in-memory tracker for async request progress."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class TaskRecord:
+    """Record describing the status of an async request."""
+
+    status: str = "pending"
+    result: dict[str, Any] | None = None
+    error: str | None = None
+
+
+_tasks: Dict[str, TaskRecord] = {}
+
+
+def create_task(task_id: str) -> None:
+    """Create a new task entry."""
+    _tasks[task_id] = TaskRecord()
+
+
+def set_result(task_id: str, result: dict[str, Any]) -> None:
+    rec = _tasks.get(task_id)
+    if rec:
+        rec.status = "completed"
+        rec.result = result
+
+
+def set_error(task_id: str, error: str) -> None:
+    rec = _tasks.get(task_id)
+    if rec:
+        rec.status = "error"
+        rec.error = error
+
+
+def get_task(task_id: str) -> TaskRecord | None:
+    return _tasks.get(task_id)

--- a/backend/tests/unit/api/v1/test_openai_integration.py
+++ b/backend/tests/unit/api/v1/test_openai_integration.py
@@ -27,6 +27,11 @@ def make_error(error_cls, status_code=400):
 
 def test_edit_image(client, monkeypatch):
     patch_service(monkeypatch)
+
+    async def immediate(request_id, image, mask, prompt):
+        openai_integration.task_manager.set_result(request_id, {"detail": "ok"})
+
+    monkeypatch.setattr(openai_integration, "_process_request", immediate)
     file_content = io.BytesIO(b"data")
     response = client.post(
         "/api/v1/images/edit",
@@ -34,7 +39,14 @@ def test_edit_image(client, monkeypatch):
         data={"prompt": "edit"},
     )
     assert response.status_code == 200
-    assert response.json() == {"detail": "ok"}
+    request_id = response.json()["request_id"]
+    status_resp = client.get(f"/api/v1/images/status/{request_id}")
+    assert status_resp.status_code == 200
+    assert status_resp.json() == {
+        "request_id": request_id,
+        "status": "completed",
+        "result": {"detail": "ok"},
+    }
 
 
 def test_edit_image_invalid_type(client, monkeypatch):
@@ -75,29 +87,38 @@ def test_edit_image_invalid_mask(client, monkeypatch):
 
 
 def test_get_status(client):
-    response = client.get("/api/v1/images/status/abc123")
+    task_id = "abc123"
+    openai_integration.task_manager.create_task(task_id)
+    openai_integration.task_manager.set_result(task_id, {"ok": True})
+    response = client.get(f"/api/v1/images/status/{task_id}")
     assert response.status_code == 200
-    assert response.json() == {"request_id": "abc123", "status": "pending"}
+    assert response.json() == {
+        "request_id": task_id,
+        "status": "completed",
+        "result": {"ok": True},
+    }
 
 
 @pytest.mark.parametrize(
-    "error_cls,status",
+    "error_cls",
     [
-        (openai.BadRequestError, 400),
-        (openai.RateLimitError, 429),
-        (openai.APIConnectionError, 502),
+        openai.BadRequestError,
+        openai.RateLimitError,
+        openai.APIConnectionError,
     ],
 )
-def test_openai_error_mapping(client, monkeypatch, error_cls, status):
-    class FailService:
-        async def edit_image(self, image: bytes, mask: bytes | None, prompt: str):
-            raise make_error(error_cls)
+def test_openai_error_mapping(client, monkeypatch, error_cls):
+    async def fail_task(request_id, image, mask, prompt):
+        openai_integration.task_manager.set_error(request_id, "boom")
 
-    monkeypatch.setattr(openai_integration, "OpenAIService", lambda: FailService())
+    monkeypatch.setattr(openai_integration, "_process_request", fail_task)
     file_content = io.BytesIO(b"data")
     response = client.post(
         "/api/v1/images/edit",
         files={"image": ("test.png", file_content, "image/png")},
         data={"prompt": "edit"},
     )
-    assert response.status_code == status
+    assert response.status_code == 200
+    request_id = response.json()["request_id"]
+    status_resp = client.get(f"/api/v1/images/status/{request_id}")
+    assert status_resp.json()["status"] == "error"


### PR DESCRIPTION
## Summary
- add a simple task manager to track async image edits
- queue OpenAI image edit requests in background tasks
- expose progress and results via `/images/status/{request_id}`
- update unit tests for async workflow
- document the change in the task list and changelog

## Testing
- `flake8`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684cb74ed410833186ebfab50e255c5c