### PR TITLE
Implement ETA progress indicator

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -135,7 +135,7 @@
   - [x] 2.5 Add comprehensive unit tests for OpenAI service functions
   - [x] 2.6 Test integration with various image sizes and mask complexities
 
-- [ ] 3.0 Create OpenAI API Endpoints (FR1-FR5, US5, US7)
+- [x] 3.0 Create OpenAI API Endpoints (FR1-FR5, US5, US7)
   - [x] 3.1 Create `backend/app/api/v1/endpoints/openai_integration.py`
   - [x] 3.2 Implement `POST /api/v1/images/edit` endpoint for OpenAI image editing
   - [x] 3.3 Implement `GET /api/v1/images/status/{request_id}` for progress tracking
@@ -171,10 +171,10 @@
   - [x] 6.5 Optimize image loading and display performance
   - [x] 6.6 Create unit tests for results display functionality
 
-- [ ] 7.0 Implement Progress and Error Handling (FR19-FR22, US5, US7)
+- [x] 7.0 Implement Progress and Error Handling (FR19-FR22, US5, US7)
   - [x] 7.1 Create `ProgressIndicator.tsx` component with loading animations
   - [x] 7.2 Implement progress tracking for long-running API requests
-  - [ ] 7.3 Add estimated completion time display
+  - [x] 7.3 Add estimated completion time display
   - [x] 7.4 Create `ErrorBoundary.tsx` for graceful error recovery
   - [x] 7.5 Implement retry functionality for failed requests
   - [x] 7.6 Add user-friendly error messages for different failure scenarios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,4 @@
 2025-06-13 Added undo/redo mask functionality with tests
 2025-06-13 Added PNG compression to OpenAI service
 2025-06-13 Added async processing with progress tracking for image edits
+2025-06-13 Added ETA display for OpenAI task progress

--- a/backend/app/api/v1/endpoints/openai_integration.py
+++ b/backend/app/api/v1/endpoints/openai_integration.py
@@ -73,7 +73,8 @@ async def edit_image(
         img_bytes = await image.read()
         mask_bytes = await mask.read() if mask else None
         request_id = uuid4().hex
-        task_manager.create_task(request_id)
+        eta_seconds = 30
+        task_manager.create_task(request_id, eta_seconds)
         background_tasks.add_task(
             _process_request, request_id, img_bytes, mask_bytes, prompt
         )
@@ -123,7 +124,7 @@ async def edit_image(
             detail=str(exc),
         )
     logger.info("/images/edit queued in %.3f", time.time() - start)
-    return {"request_id": request_id}
+    return {"request_id": request_id, "eta_seconds": eta_seconds}
 
 
 @router.get("/images/status/{request_id}")
@@ -137,6 +138,11 @@ async def get_status(request_id: str) -> dict[str, object]:
         "request_id": request_id,
         "status": record.status,
     }
+    if record.status in {"completed", "error"}:
+        eta = 0
+    else:
+        eta = max(int(record.start_time + record.eta_seconds - time.time()), 0)
+    response["eta_seconds"] = eta
     if record.result is not None:
         response["result"] = record.result
     if record.error is not None:

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import time
 from typing import Any, Dict
 
 
@@ -13,14 +14,16 @@ class TaskRecord:
     status: str = "pending"
     result: dict[str, Any] | None = None
     error: str | None = None
+    start_time: float = field(default_factory=time.time)
+    eta_seconds: int = 30
 
 
 _tasks: Dict[str, TaskRecord] = {}
 
 
-def create_task(task_id: str) -> None:
-    """Create a new task entry."""
-    _tasks[task_id] = TaskRecord()
+def create_task(task_id: str, eta_seconds: int = 30) -> None:
+    """Create a new task entry with optional ETA."""
+    _tasks[task_id] = TaskRecord(eta_seconds=eta_seconds)
 
 
 def set_result(task_id: str, result: dict[str, Any]) -> None:

--- a/backend/tests/unit/api/v1/test_openai_integration.py
+++ b/backend/tests/unit/api/v1/test_openai_integration.py
@@ -39,13 +39,16 @@ def test_edit_image(client, monkeypatch):
         data={"prompt": "edit"},
     )
     assert response.status_code == 200
-    request_id = response.json()["request_id"]
+    data = response.json()
+    request_id = data["request_id"]
+    assert data["eta_seconds"] == 30
     status_resp = client.get(f"/api/v1/images/status/{request_id}")
     assert status_resp.status_code == 200
     assert status_resp.json() == {
         "request_id": request_id,
         "status": "completed",
         "result": {"detail": "ok"},
+        "eta_seconds": 0,
     }
 
 
@@ -96,6 +99,7 @@ def test_get_status(client):
         "request_id": task_id,
         "status": "completed",
         "result": {"ok": True},
+        "eta_seconds": 0,
     }
 
 
@@ -121,4 +125,6 @@ def test_openai_error_mapping(client, monkeypatch, error_cls):
     assert response.status_code == 200
     request_id = response.json()["request_id"]
     status_resp = client.get(f"/api/v1/images/status/{request_id}")
-    assert status_resp.json()["status"] == "error"
+    data = status_resp.json()
+    assert data["status"] == "error"
+    assert data["eta_seconds"] == 0

--- a/frontend/src/components/CanvasDisplay.tsx
+++ b/frontend/src/components/CanvasDisplay.tsx
@@ -37,6 +37,7 @@ export default function CanvasDisplay({ image, prompt, onResult, onError }: Prop
   const [submitMsg, setSubmitMsg] = useState('');
   const [submitError, setSubmitError] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [eta, setEta] = useState<number | null>(null);
 
   useEffect(() => {
     const canvas = baseRef.current;
@@ -78,6 +79,7 @@ export default function CanvasDisplay({ image, prompt, onResult, onError }: Prop
     setSubmitting(true);
     setSubmitMsg('Processing...');
     setSubmitError('');
+    setEta(null);
     try {
       const [maskBlob, imgBlob] = await Promise.all([
         new Promise<Blob | null>((resolve) =>
@@ -94,6 +96,7 @@ export default function CanvasDisplay({ image, prompt, onResult, onError }: Prop
         ? new File([imgBlob], 'image.png', { type: 'image/png' })
         : image;
       const result = await editImage(imageFile, prompt || 'Edit', maskFile);
+      setEta(result.eta_seconds ?? null);
       onResult?.(imageFile);
       setSubmitMsg(result.detail || 'Processing complete');
     } catch (err) {
@@ -171,7 +174,9 @@ export default function CanvasDisplay({ image, prompt, onResult, onError }: Prop
           >
             Submit
           </button>
-          {submitting && <ProgressIndicator message="Processing..." />}
+          {submitting && (
+            <ProgressIndicator message="Processing..." etaSeconds={eta ?? undefined} />
+          )}
           {submitMsg && <div className="mt-2 text-green-600">{submitMsg}</div>}
           {submitError && (
             <div className="mt-2 text-red-600">Error: {submitError}</div>

--- a/frontend/src/components/ProgressIndicator.test.tsx
+++ b/frontend/src/components/ProgressIndicator.test.tsx
@@ -10,8 +10,11 @@ describe('ProgressIndicator', () => {
   });
 
   it('shows custom message and progress', () => {
-    const { getByText } = render(<ProgressIndicator message="Processing" progress={50} />);
+    const { getByText } = render(
+      <ProgressIndicator message="Processing" progress={50} etaSeconds={10} />,
+    );
     expect(getByText('Processing')).toBeTruthy();
     expect(getByText('50%')).toBeTruthy();
+    expect(getByText('ETA: 10s')).toBeTruthy();
   });
 });

--- a/frontend/src/components/ProgressIndicator.tsx
+++ b/frontend/src/components/ProgressIndicator.tsx
@@ -3,12 +3,17 @@ import React from 'react';
 interface Props {
   message?: string;
   progress?: number; // 0-100
+  etaSeconds?: number;
 }
 
 /**
  * Displays a simple progress indicator with optional message and progress percent.
  */
-export default function ProgressIndicator({ message = 'Loading...', progress }: Props) {
+export default function ProgressIndicator({
+  message = 'Loading...',
+  progress,
+  etaSeconds,
+}: Props) {
   return (
     <div className="flex items-center gap-2" aria-label="progress-indicator">
       <svg
@@ -33,6 +38,7 @@ export default function ProgressIndicator({ message = 'Loading...', progress }: 
       </svg>
       <span>{message}</span>
       {progress !== undefined && <span>{progress}%</span>}
+      {etaSeconds !== undefined && <span>ETA: {etaSeconds}s</span>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- complete task 7.3 for progress ETA
- store ETA in backend task manager and expose it via API
- show ETA in `ProgressIndicator` component
- display ETA when submitting edits
- update unit tests
- mark tasks completed and update changelog

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684cb9915f908331a89a449b29c29a15