### PR TITLE
Implement editing workflow polling

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -185,7 +185,7 @@
   - [x] 8.2 Connect `PromptInput.tsx` to validation and submission workflow
   - [x] 8.3 Integrate enhanced `CanvasDisplay.tsx` with mask export for API submission
   - [x] 8.4 Connect `ResultsDisplay.tsx` to receive and display API responses
-  - [ ] 8.5 Implement complete edit workflow in `HomePage.tsx`
+  - [x] 8.5 Implement complete edit workflow in `HomePage.tsx`
   - [x] 8.6 Add proper loading states and error handling throughout the UI
   - [ ] 8.7 Test end-to-end functionality with real OpenAI API calls
 

--- a/frontend/src/components/CanvasDisplay.tsx
+++ b/frontend/src/components/CanvasDisplay.tsx
@@ -15,9 +15,16 @@ interface Props {
   prompt: string;
   onResult?: (file: File) => void;
   onError?: (msg: string) => void;
+  onRequestId?: (id: string) => void;
 }
 
-export default function CanvasDisplay({ image, prompt, onResult, onError }: Props) {
+export default function CanvasDisplay({
+  image,
+  prompt,
+  onResult,
+  onError,
+  onRequestId,
+}: Props) {
   const baseRef = useRef<HTMLCanvasElement>(null);
   const {
     canvasRef: maskRef,
@@ -97,6 +104,9 @@ export default function CanvasDisplay({ image, prompt, onResult, onError }: Prop
         : image;
       const result = await editImage(imageFile, prompt || 'Edit', maskFile);
       setEta(result.eta_seconds ?? null);
+      if (result.request_id) {
+        onRequestId?.(result.request_id);
+      }
       onResult?.(imageFile);
       setSubmitMsg(result.detail || 'Processing complete');
     } catch (err) {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { fetchEditStatus } from '../services/apiClient';
 import HealthCheckDisplay from '../components/HealthCheckDisplay';
 import FileUpload from '../components/FileUpload';
 import CanvasDisplay from '../components/CanvasDisplay';
@@ -11,21 +12,71 @@ export default function HomePage() {
   const [prompt, setPrompt] = useState('');
   const [result, setResult] = useState<File | null>(null);
   const [error, setError] = useState('');
-  const handlePrompt = (p: string) => setPrompt(p);
+  const [requestId, setRequestId] = useState<string | null>(null);
+  const handleUpload = (f: File) => {
+    setImage(f);
+    setResult(null);
+    setRequestId(null);
+  };
+  const handlePrompt = (p: string) => {
+    setPrompt(p);
+    setResult(null);
+    setRequestId(null);
+  };
+  const handleCanvasResult = (file: File) => {
+    void file; // preview ignored until processing completes
+  };
+
+  useEffect(() => {
+    if (!requestId) return;
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const status = await fetchEditStatus(requestId);
+        if (status.status === 'completed' && status.result?.data?.[0]?.url) {
+          const res = await fetch(status.result.data[0].url);
+          const blob = await res.blob();
+          const file = new File([blob], 'result.png', { type: 'image/png' });
+          if (!cancelled) {
+            setResult(file);
+            setError('');
+            clearInterval(interval);
+          }
+        } else if (status.status === 'error') {
+          if (!cancelled) {
+            setError(status.error || 'Processing failed');
+            clearInterval(interval);
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError((err as Error).message);
+          clearInterval(interval);
+        }
+      }
+    };
+    const interval = setInterval(poll, 3000);
+    poll();
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [requestId]);
   return (
     <ErrorBoundary fallback={<p>Something went wrong.</p>}>
       <div>
         <h1>Welcome to Shiny Broccoli</h1>
         <HealthCheckDisplay />
         <div className="my-4">
-          <FileUpload onUploaded={setImage} />
+          <FileUpload onUploaded={handleUpload} />
         </div>
         <PromptInput onSubmit={handlePrompt} />
         <CanvasDisplay
           image={image}
           prompt={prompt}
-          onResult={setResult}
+          onResult={handleCanvasResult}
           onError={setError}
+          onRequestId={setRequestId}
         />
         {image && (
           <ResultsDisplay


### PR DESCRIPTION
## Summary
- task list: mark HomePage workflow task complete
- CanvasDisplay: expose request ID when submitting
- HomePage: poll for edit status and show result

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh -no_integration`


------
https://chatgpt.com/codex/tasks/task_e_684cbd95ef348331bac62a6139a4172a