### PR TITLE
Implement performance logging and canvas optimizations

### DIFF
--- a/.project-management/current-prd/tasks-prd-core-functionality-epic.md
+++ b/.project-management/current-prd/tasks-prd-core-functionality-epic.md
@@ -82,6 +82,7 @@
 - `backend/services/openai_service.py` - Service for handling OpenAI API calls with PNG compression.
 - `backend/services/task_manager.py` - Simple in-memory tracker for async request progress.
 - `backend/app/logging.py` - Logging configuration utilities.
+- `backend/app/middleware.py` - HTTP middleware for request timing metrics.
 - `backend/tests/api/v1/test_openai_integration.py` - Unit tests for OpenAI integration endpoints.
 - `backend/tests/unit/services/test_openai_service.py` - Unit tests for OpenAI service.
 - `docs/user_guide.md` - User guide for the complete image editing workflow.
@@ -190,12 +191,12 @@
   - [ ] 8.7 Test end-to-end functionality with real OpenAI API calls
 
 - [ ] 9.0 Performance Optimization and Polish (SM1-SM7)
-  - [ ] 9.1 Optimize canvas operations for smooth mask drawing performance
+  - [x] 9.1 Optimize canvas operations for smooth mask drawing performance
   - [x] 9.2 Implement image compression for large uploads to meet OpenAI size limits
   - [x] 9.3 Add client-side validation for image dimensions and format compatibility
-  - [ ] 9.4 Optimize memory usage for large images and long editing sessions
+  - [x] 9.4 Optimize memory usage for large images and long editing sessions
   - [ ] 9.5 Test performance across different browsers and devices
-  - [ ] 9.6 Add performance monitoring and logging for optimization
+  - [x] 9.6 Add performance monitoring and logging for optimization
 
 - [ ] 10.0 Testing and Documentation for Phase 2 Completion (SM6, SM7)
   - [ ] 10.1 Create comprehensive integration tests for the complete editing workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,4 @@
 2025-06-13 Added PNG compression to OpenAI service
 2025-06-13 Added async processing with progress tracking for image edits
 2025-06-13 Added ETA display for OpenAI task progress
+2025-06-14 Added timing middleware and canvas optimization

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from .middleware import TimingMiddleware
+
 from .logging import setup_logging
 
 from .core.config import get_settings
@@ -22,6 +24,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.add_middleware(TimingMiddleware)
 
 app.include_router(health_router, prefix="/api/v1")
 app.include_router(images_router, prefix="/api/v1")

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+import time
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+
+class TimingMiddleware(BaseHTTPMiddleware):
+    """Middleware that logs request processing time."""
+
+    def __init__(self, app: ASGIApp, logger: logging.Logger | None = None) -> None:
+        super().__init__(app)
+        self.logger = logger or logging.getLogger("timing")
+
+    async def dispatch(self, request: Request, call_next):
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration = (time.perf_counter() - start) * 1000
+        response.headers["X-Process-Time"] = f"{duration:.2f}"
+        self.logger.info(
+            "%s %s %.2fms", request.method, request.url.path, duration
+        )
+        return response

--- a/backend/tests/unit/api/v1/test_health.py
+++ b/backend/tests/unit/api/v1/test_health.py
@@ -2,3 +2,4 @@ def test_health(client):
     response = client.get("/api/v1/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+    assert "X-Process-Time" in response.headers

--- a/frontend/src/hooks/useCanvas.test.tsx
+++ b/frontend/src/hooks/useCanvas.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import useCanvas from './useCanvas';
+import useCanvas, { MAX_HISTORY } from './useCanvas';
 
 describe('useCanvas', () => {
   it('toggles drawing mode', () => {
@@ -81,5 +81,36 @@ describe('useCanvas', () => {
       result.current.redo();
     });
     expect(putImageData).toHaveBeenCalledTimes(2);
+  });
+
+  it('limits undo history to MAX_HISTORY', () => {
+    const { result } = renderHook(() => useCanvas());
+    const canvas = document.createElement('canvas');
+    canvas.width = 10;
+    canvas.height = 10;
+    const ctx = {
+      fillRect: vi.fn(),
+      getImageData: vi.fn(() => ({ data: new Uint8ClampedArray(1) })),
+      putImageData: vi.fn(),
+      globalCompositeOperation: 'source-over',
+      fillStyle: 'white',
+    } as unknown as CanvasRenderingContext2D;
+    canvas.getContext = vi.fn(() => ctx);
+    result.current.canvasRef.current = canvas;
+
+    for (let i = 0; i < MAX_HISTORY + 5; i++) {
+      act(() => {
+        result.current.clear();
+      });
+    }
+
+    let count = 0;
+    while (result.current.canUndo) {
+      act(() => {
+        result.current.undo();
+      });
+      count += 1;
+    }
+    expect(count).toBe(MAX_HISTORY);
   });
 });

--- a/frontend/src/hooks/useCanvas.ts
+++ b/frontend/src/hooks/useCanvas.ts
@@ -7,6 +7,8 @@ import { useRef, useEffect, useState } from 'react';
 export type BrushSize = 'small' | 'medium' | 'large';
 export type Tool = 'brush' | 'rectangle' | 'circle';
 
+export const MAX_HISTORY = 20;
+
 export default function useCanvas() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const drawing = useRef(false);
@@ -30,6 +32,9 @@ export default function useCanvas() {
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
+    if (history.current.length >= MAX_HISTORY) {
+      history.current.shift();
+    }
     history.current.push(ctx.getImageData(0, 0, canvas.width, canvas.height));
     redoStack.current = [];
     forceRender({});
@@ -49,6 +54,9 @@ export default function useCanvas() {
     const startDraw = (e: PointerEvent) => {
       drawing.current = true;
       startPos.current = { x: e.offsetX, y: e.offsetY };
+      if (history.current.length >= MAX_HISTORY) {
+        history.current.shift();
+      }
       history.current.push(
         ctx.getImageData(0, 0, canvas.width, canvas.height),
       );
@@ -99,14 +107,29 @@ export default function useCanvas() {
       canvas.style.cursor = 'default';
     };
 
+    let raf = 0;
+    let pending: PointerEvent | null = null;
+    const throttledDraw = (e: PointerEvent) => {
+      pending = e;
+      if (!raf) {
+        raf = requestAnimationFrame(() => {
+          raf = 0;
+          if (pending) {
+            draw(pending);
+            pending = null;
+          }
+        });
+      }
+    };
+
     canvas.addEventListener('pointerdown', startDraw);
-    canvas.addEventListener('pointermove', draw);
+    canvas.addEventListener('pointermove', throttledDraw);
     canvas.addEventListener('pointerup', stopDraw);
     canvas.addEventListener('pointerleave', stopDraw);
 
     return () => {
       canvas.removeEventListener('pointerdown', startDraw);
-      canvas.removeEventListener('pointermove', draw);
+      canvas.removeEventListener('pointermove', throttledDraw);
       canvas.removeEventListener('pointerup', stopDraw);
       canvas.removeEventListener('pointerleave', stopDraw);
     };
@@ -118,7 +141,12 @@ export default function useCanvas() {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     const prev = history.current.pop()!;
-    redoStack.current.push(ctx.getImageData(0, 0, canvas.width, canvas.height));
+    if (redoStack.current.length >= MAX_HISTORY) {
+      redoStack.current.shift();
+    }
+    redoStack.current.push(
+      ctx.getImageData(0, 0, canvas.width, canvas.height),
+    );
     ctx.putImageData(prev, 0, 0);
     forceRender({});
   };
@@ -129,7 +157,12 @@ export default function useCanvas() {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     const next = redoStack.current.pop()!;
-    history.current.push(ctx.getImageData(0, 0, canvas.width, canvas.height));
+    if (history.current.length >= MAX_HISTORY) {
+      history.current.shift();
+    }
+    history.current.push(
+      ctx.getImageData(0, 0, canvas.width, canvas.height),
+    );
     ctx.putImageData(next, 0, 0);
     forceRender({});
   };


### PR DESCRIPTION
## Summary
- optimize canvas operations and history size
- add request timing middleware and header
- test performance middleware and canvas hook
- update task list
- record changes in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684cc09815848331b0d26afc9197efe8