### PR TITLE
Improve accessibility with labels and focus styles

### DIFF
--- a/.project-management/current-prd/tasks-prd-polish-learning-epic.md
+++ b/.project-management/current-prd/tasks-prd-polish-learning-epic.md
@@ -95,10 +95,17 @@
 - `README.md` - Add beginner-friendly tutorial.
 - `DEVELOPMENT.md` - Document full environment setup steps.
 - `dev_init.sh` - Utilize `.env.template` files if `.env` is missing.
-- `frontend/src/components/PromptInput.tsx` - Include sample prompts.
-- `frontend/src/components/FileUpload.tsx` - Add accessible labels.
-- `frontend/src/components/CanvasDisplay.tsx` - Ensure focus outlines.
+- `frontend/src/components/PromptInput.tsx` - Include sample prompts and accessibility improvements.
+- `frontend/src/components/FileUpload.tsx` - Add accessible labels and focus states.
+- `frontend/src/components/CanvasDisplay.tsx` - Ensure focus outlines and labels.
+- `frontend/src/components/ResultsDisplay.tsx` - Add accessible toggle labels.
+- `frontend/src/components/ErrorBoundary.tsx` - Label reset button.
+- `frontend/src/components/MaskToolbar.tsx` - Improve focus visibility on inputs.
+- `frontend/src/components/PromptInput.test.tsx` - Test placeholder prompt.
+- `frontend/src/components/FileUpload.test.tsx` - Test upload button label.
+- `frontend/src/components/CanvasDisplay.test.tsx` - Check accessibility label.
 - `CHANGELOG.md` - Record progress entries.
+- `.project-management/current-prd/tasks-prd-polish-learning-epic.md` - Update task status.
 
 ## Tasks
 
@@ -113,11 +120,11 @@
   - [x] 2.3 Create `.env.template` files for backend and frontend.
   - [x] 2.4 Update `dev_init.sh` to copy `.env.template` when `.env` is missing.
 
-- [ ] 3.0 Improve UI Prompting and Accessibility (FR6, FR7)
-  - [ ] 3.1 Provide example prompts within `PromptInput.tsx`.
-  - [ ] 3.2 Ensure all forms and buttons have accessible labels.
-  - [ ] 3.3 Add focus states for interactive elements.
-  - [ ] 3.4 Update or create tests for new prompts and accessibility attributes.
+- [x] 3.0 Improve UI Prompting and Accessibility (FR6, FR7)
+  - [x] 3.1 Provide example prompts within `PromptInput.tsx`.
+  - [x] 3.2 Ensure all forms and buttons have accessible labels.
+  - [x] 3.3 Add focus states for interactive elements.
+  - [x] 3.4 Update or create tests for new prompts and accessibility attributes.
 
 - [ ] 4.0 Verify Success Metrics (SM1-SM3)
   - [x] 4.1 Run `run_tests.sh -no_integration` and ensure it passes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,4 @@
 2025-06-14 Added PRD for Polish & Learning Epic (Phase 3)
 2025-06-14 Generated task list for Polish & Learning Epic
 2025-06-14 Added env templates, docs tutorial, and dev_init improvements
+2025-06-14 Improved accessibility labels and focus states across frontend

--- a/frontend/src/components/CanvasDisplay.test.tsx
+++ b/frontend/src/components/CanvasDisplay.test.tsx
@@ -47,8 +47,11 @@ global.URL.revokeObjectURL = vi.fn();
 describe('CanvasDisplay', () => {
   it('toggles mask visibility and submits', async () => {
     const file = new File(['data'], 'test.png', { type: 'image/png' });
-    const { getByText } = render(<CanvasDisplay image={file} prompt="edit" />);
+    const { getByText, getByLabelText } = render(
+      <CanvasDisplay image={file} prompt="edit" />,
+    );
     await waitFor(() => getByText('Switch to Erase'));
+    expect(getByLabelText('Toggle draw or erase mode')).toBeTruthy();
     const toggle = getByText('Hide Mask');
     fireEvent.click(toggle);
     expect(toggle.textContent).toBe('Show Mask');

--- a/frontend/src/components/CanvasDisplay.tsx
+++ b/frontend/src/components/CanvasDisplay.tsx
@@ -131,38 +131,43 @@ export default function CanvasDisplay({
             />
             <button
               type="button"
+              aria-label="Toggle draw or erase mode"
               onClick={toggleMode}
-              className="px-2 py-1 border rounded"
+              className="px-2 py-1 border rounded focus:outline focus:outline-blue-500"
             >
               {mode === 'draw' ? 'Switch to Erase' : 'Switch to Draw'}
             </button>
             <button
               type="button"
+              aria-label="Toggle mask visibility"
               onClick={() => setMaskVisible((v) => !v)}
-              className="px-2 py-1 border rounded"
+              className="px-2 py-1 border rounded focus:outline focus:outline-blue-500"
             >
               {maskVisible ? 'Hide Mask' : 'Show Mask'}
             </button>
             <button
               type="button"
+              aria-label="Clear mask"
               onClick={clear}
-              className="px-2 py-1 border rounded"
+              className="px-2 py-1 border rounded focus:outline focus:outline-blue-500"
             >
               Clear Mask
             </button>
             <button
               type="button"
+              aria-label="Undo mask action"
               onClick={undo}
               disabled={!canUndo}
-              className="px-2 py-1 border rounded"
+              className="px-2 py-1 border rounded focus:outline focus:outline-blue-500"
             >
               Undo
             </button>
             <button
               type="button"
+              aria-label="Redo mask action"
               onClick={redo}
               disabled={!canRedo}
-              className="px-2 py-1 border rounded"
+              className="px-2 py-1 border rounded focus:outline focus:outline-blue-500"
             >
               Redo
             </button>
@@ -178,9 +183,10 @@ export default function CanvasDisplay({
           </div>
           <button
             type="button"
+            aria-label="Submit image edits"
             disabled={submitting}
             onClick={handleSubmit}
-            className="mt-2 px-2 py-1 border rounded"
+            className="mt-2 px-2 py-1 border rounded focus:outline focus:outline-blue-500"
           >
             Submit
           </button>

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -33,7 +33,12 @@ export default class ErrorBoundary extends React.Component<Props, State> {
       return (
         <div role="alert">
           {this.props.fallback || <p>Something went wrong.</p>}
-          <button type="button" onClick={this.handleReset}>
+          <button
+            type="button"
+            aria-label="Reset error"
+            onClick={this.handleReset}
+            className="focus:outline focus:outline-blue-500"
+          >
             Try again
           </button>
         </div>

--- a/frontend/src/components/FileUpload.test.tsx
+++ b/frontend/src/components/FileUpload.test.tsx
@@ -39,6 +39,7 @@ describe('FileUpload', () => {
     const onUploaded = vi.fn();
     const { getByText, getByLabelText } = render(<FileUpload onUploaded={onUploaded} />);
     const input = getByLabelText('Image:');
+    expect(getByLabelText('Upload image')).toBeTruthy();
     const file = new File(['data'], 'test.png', { type: 'image/png' });
     await fireEvent.change(input, { target: { files: [file] } });
     await fireEvent.submit(getByText('Upload').closest('form') as HTMLFormElement);

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -81,8 +81,20 @@ export default function FileUpload({ onUploaded }: { onUploaded?: (file: File) =
   return (
     <form onSubmit={handleSubmit} className="p-4 border rounded">
       <label htmlFor="file-input" className="mr-2">Image:</label>
-      <input id="file-input" type="file" onChange={handleChange} accept={ACCEPTED_TYPES.join(',')} />
-      <button type="submit" disabled={!file || uploading} className="ml-2 px-2 py-1 border rounded">
+      <input
+        id="file-input"
+        aria-label="Image file"
+        className="focus:outline focus:outline-blue-500"
+        type="file"
+        onChange={handleChange}
+        accept={ACCEPTED_TYPES.join(',')}
+      />
+      <button
+        type="submit"
+        aria-label="Upload image"
+        disabled={!file || uploading}
+        className="ml-2 px-2 py-1 border rounded focus:outline focus:outline-blue-500"
+      >
         Upload
       </button>
       {uploading && <ProgressIndicator message="Uploading..." />}

--- a/frontend/src/components/MaskToolbar.tsx
+++ b/frontend/src/components/MaskToolbar.tsx
@@ -30,6 +30,7 @@ export default function MaskToolbar({ brushSize, setBrushSize, tool, setTool }: 
               value={opt}
               checked={brushSize === opt}
               onChange={() => setBrushSize(opt)}
+              className="focus:outline focus:outline-blue-500"
             />
             {label(opt)}
           </label>
@@ -45,6 +46,7 @@ export default function MaskToolbar({ brushSize, setBrushSize, tool, setTool }: 
               value={t}
               checked={tool === t}
               onChange={() => setTool(t)}
+              className="focus:outline focus:outline-blue-500"
             />
             {t}
           </label>

--- a/frontend/src/components/PromptInput.test.tsx
+++ b/frontend/src/components/PromptInput.test.tsx
@@ -27,6 +27,13 @@ describe('PromptInput', () => {
     expect(getByText(/Example prompts/i)).toBeTruthy();
   });
 
+  it('renders placeholder text', () => {
+    const { getByPlaceholderText } = render(<PromptInput />);
+    expect(
+      getByPlaceholderText('e.g. Remove the background')
+    ).toBeTruthy();
+  });
+
   it('stores prompt and displays recent list', () => {
     const { getByText, getByLabelText } = render(<PromptInput />);
     const textarea = getByLabelText('Prompt');

--- a/frontend/src/components/PromptInput.tsx
+++ b/frontend/src/components/PromptInput.tsx
@@ -61,10 +61,11 @@ export default function PromptInput({
     <form onSubmit={handleSubmit} className="p-4 border rounded">
       <textarea
         aria-label="Prompt"
+        placeholder="e.g. Remove the background"
         value={prompt}
         onChange={handleChange}
         maxLength={maxLength}
-        className="w-full border rounded p-2"
+        className="w-full border rounded p-2 focus:outline focus:outline-blue-500"
       />
       <div className="text-sm text-gray-600 mt-1">
         {prompt.length}/{maxLength}
@@ -75,7 +76,8 @@ export default function PromptInput({
             Example prompts:
             <button
               type="button"
-              className="ml-2 underline"
+              aria-label="Use example prompt Remove the background"
+              className="ml-2 underline focus:outline focus:outline-blue-500"
               onClick={() => setPrompt('Remove the background')}
             >
               Remove the background
@@ -83,7 +85,8 @@ export default function PromptInput({
             ,
             <button
               type="button"
-              className="ml-1 underline"
+              aria-label="Use example prompt Change sky color"
+              className="ml-1 underline focus:outline focus:outline-blue-500"
               onClick={() => setPrompt('Change sky color to blue')}
             >
               Change sky color
@@ -96,7 +99,8 @@ export default function PromptInput({
               <button
                 key={p}
                 type="button"
-                className="ml-2 underline"
+                aria-label={`Use recent prompt ${p}`}
+                className="ml-2 underline focus:outline focus:outline-blue-500"
                 onClick={() => setPrompt(p)}
               >
                 {p}
@@ -111,7 +115,8 @@ export default function PromptInput({
           <button
             key={s}
             type="button"
-            className="ml-2 underline"
+            aria-label={`Use suggestion ${s}`}
+            className="ml-2 underline focus:outline focus:outline-blue-500"
             onClick={() => setPrompt(s)}
           >
             {s}
@@ -120,8 +125,9 @@ export default function PromptInput({
       </div>
       <button
         type="submit"
+        aria-label="Submit prompt"
         disabled={!prompt.trim() || prompt.length > maxLength}
-        className="mt-2 px-2 py-1 border rounded"
+        className="mt-2 px-2 py-1 border rounded focus:outline focus:outline-blue-500"
       >
         Submit
       </button>

--- a/frontend/src/components/ResultsDisplay.tsx
+++ b/frontend/src/components/ResultsDisplay.tsx
@@ -45,10 +45,11 @@ export default function ResultsDisplay({ original, result, error }: Props) {
     <div>
       <button
         type="button"
+        aria-label="Toggle result display mode"
         onClick={() =>
           setMode((m) => (m === 'side-by-side' ? 'overlay' : 'side-by-side'))
         }
-        className="mb-2 px-2 py-1 border rounded"
+        className="mb-2 px-2 py-1 border rounded focus:outline focus:outline-blue-500"
       >
         {mode === 'side-by-side' ? 'Overlay' : 'Side by Side'}
       </button>
@@ -56,7 +57,7 @@ export default function ResultsDisplay({ original, result, error }: Props) {
         <a
           href={resultUrl}
           download="result.png"
-          className="ml-2 underline"
+          className="ml-2 underline focus:outline focus:outline-blue-500"
           aria-label="download-result"
         >
           Download


### PR DESCRIPTION
## Summary
- add placeholder example prompt and aria labels in PromptInput
- improve FileUpload accessibility
- add labels and focus outlines across CanvasDisplay
- label ResultsDisplay toggle and download link
- label ErrorBoundary reset button
- show focus on MaskToolbar controls
- test for placeholder and label behaviour
- record changes in CHANGELOG
- update task list

## Testing
- `npm run lint`
- `flake8`
- `./run_tests.sh -no_integration`


------
https://chatgpt.com/codex/tasks/task_e_684cdf3709388331999d4c146913d504