### PR TITLE
Add PRD for task management feature

### DIFF
--- a/.project-management/current-prd/prd-task-management.md
+++ b/.project-management/current-prd/prd-task-management.md
@@ -1,0 +1,48 @@
+## 1. Introduction/Overview
+This PRD proposes adding a simple task management feature to help users track to-do items directly within the Shiny-Broccoli application. The goal is to provide a lightweight checklist so users can record tasks, mark them complete, and keep their work organized without leaving the app.
+
+## 2. Goals
+- **G1**: Allow users to create tasks with a title and optional description.
+- **G2**: Provide the ability to edit or delete tasks.
+- **G3**: Display a list of tasks with clear indicators for completed items.
+- **G4**: Persist tasks in the browser so that data remains after a page reload.
+
+## 3. User Stories
+- **US1**: As a user, I want to add tasks so that I can remember work I need to do.
+- **US2**: As a user, I want to edit a task so that I can change details when plans change.
+- **US3**: As a user, I want to mark tasks complete so that I can see what I've finished.
+- **US4**: As a user, I want my tasks to remain if I refresh the page so that I don't lose them accidentally.
+
+## 4. Functional Requirements
+1. The system must provide a form to create a new task with a required title and optional description.
+2. The system must display all tasks in a list sorted by creation time.
+3. The system must allow users to edit a task's title and description.
+4. The system must allow users to delete a task.
+5. The system must allow users to mark a task as complete or incomplete.
+6. The system must store tasks in browser local storage so they persist across sessions.
+
+## 5. Non-Goals (Out of Scope)
+- User authentication or sharing tasks between users.
+- Advanced filtering or tagging of tasks.
+- Integration with external task services.
+
+## 6. Design Considerations
+- Use existing frontend styling to match the rest of the application.
+- Provide simple buttons or checkboxes to mark tasks complete.
+- Keep the interface minimal to avoid distracting from the core image editing workflow.
+
+## 7. Technical Considerations
+- Implement task persistence using `localStorage` on the frontend only; no backend changes are required.
+- Follow existing project linting rules and testing approach for any new components.
+
+## 8. Success Metrics
+- Users can create, edit, and delete tasks without errors.
+- Completed tasks visually differ from incomplete ones.
+- Tasks remain after page reload, demonstrating persistence.
+
+## 9. Open Questions
+- Should tasks be limited in number to avoid excessive storage use?
+- Do we need undo functionality for deleting tasks?
+
+## 10. Referenced PRD-background files
+- None. No additional background files were provided for this feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,3 +54,4 @@
 2025-06-14 Improved accessibility labels and focus states across frontend
 2025-06-14 Documented backend modules and added placeholder components
 2025-06-14 Closed Polish & Learning Epic PRD
+2025-06-14 Created PRD for simple task management feature


### PR DESCRIPTION
## Summary
- propose a new simple Task Management feature
- document goals, user stories, and requirements in `prd-task-management.md`
- record change in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684cea1dd01083319d6b3a07e7d9d4be