### PR TITLE
Implement pydantic settings

### DIFF
--- a/.project-management/current-prd/tasks-prd-backend-hardening-epic.md
+++ b/.project-management/current-prd/tasks-prd-backend-hardening-epic.md
@@ -106,13 +106,13 @@ shiny-broccoli/
 ## Tasks
 
 - [ ] 1.0 Implement Pydantic Settings Configuration Management
-  - [ ] 1.1 Create `backend/app/core/settings.py` with `BaseSettings` class extending pydantic-settings
-  - [ ] 1.2 Define environment variables for `openai_api_key`, `allow_origins`, `log_level`, `redis_url` (optional)
-  - [ ] 1.3 Add support for `.env` file loading with `_env_file = ".env"` setting
-  - [ ] 1.4 Create `backend/.env.example` template with all configuration variables documented
-  - [ ] 1.5 Update `backend/app/core/config.py` to use new Settings class and maintain `get_settings()` function
-  - [ ] 1.6 Test configuration loading from environment variables and .env file
-  - [ ] 1.7 Update all imports throughout codebase to use new settings module
+  - [x] 1.1 Create `backend/app/core/settings.py` with `BaseSettings` class extending pydantic-settings
+  - [x] 1.2 Define environment variables for `openai_api_key`, `allow_origins`, `log_level`, `redis_url` (optional)
+  - [x] 1.3 Add support for `.env` file loading with `_env_file = ".env"` setting
+  - [x] 1.4 Create `backend/.env.example` template with all configuration variables documented
+  - [x] 1.5 Update `backend/app/core/config.py` to use new Settings class and maintain `get_settings()` function
+  - [x] 1.6 Test configuration loading from environment variables and .env file
+  - [c] 1.7 Update all imports throughout codebase to use new settings module
 
 - [ ] 2.0 Establish Dependency Injection System
   - [ ] 2.1 Create `backend/app/core/dependencies.py` with dependency provider functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,4 @@
 2025-06-14 Documented backend modules and added placeholder components
 2025-06-14 Closed Polish & Learning Epic PRD
 2025-06-14 Created PRD for simple task management feature
+2025-06-14 Added Pydantic settings management and configuration tests

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+# Example environment configuration for the Shiny Broccoli backend
+OPENAI_API_KEY=
+ALLOW_ORIGINS=http://localhost:5173
+LOG_LEVEL=INFO
+# Uncomment to enable Redis based task persistence
+# REDIS_URL=redis://localhost:6379/0

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,25 +1,11 @@
-"""Application configuration management utilities."""
+"""Application configuration helpers."""
 
-from dataclasses import dataclass
 from functools import lru_cache
-import os
 
-
-@dataclass
-class Settings:
-    allow_origins: str = "http://localhost:5173"
-    openai_api_key: str | None = None
-
-    @classmethod
-    def from_env(cls) -> "Settings":
-        """Create a Settings instance populated from environment variables."""
-        return cls(
-            allow_origins=os.getenv("ALLOW_ORIGINS", "http://localhost:5173"),
-            openai_api_key=os.getenv("OPENAI_API_KEY"),
-        )
+from .settings import Settings
 
 
 @lru_cache()
 def get_settings() -> Settings:
     """Return cached Settings instance."""
-    return Settings.from_env()
+    return Settings()

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+"""Application configuration management using Pydantic BaseSettings."""
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Configuration loaded from environment variables or .env file."""
+
+    openai_api_key: str | None = Field(default=None, env="OPENAI_API_KEY")
+    allow_origins: str = Field(default="http://localhost:5173", env="ALLOW_ORIGINS")
+    log_level: str = Field(default="INFO", env="LOG_LEVEL")
+    redis_url: str | None = Field(default=None, env="REDIS_URL")
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")

--- a/backend/tests/unit/core/test_settings.py
+++ b/backend/tests/unit/core/test_settings.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from backend.app.core.settings import Settings
+
+
+def test_env_file_loading(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "\n".join([
+            "OPENAI_API_KEY=test-key",
+            "ALLOW_ORIGINS=http://example.com",
+            "LOG_LEVEL=DEBUG",
+            "REDIS_URL=redis://localhost:6379/1",
+        ])
+    )
+    monkeypatch.chdir(tmp_path)
+    settings = Settings()
+    assert settings.openai_api_key == "test-key"
+    assert settings.allow_origins == "http://example.com"
+    assert settings.log_level == "DEBUG"
+    assert settings.redis_url == "redis://localhost:6379/1"
+
+
+def test_env_variables_override(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    settings = Settings(_env_file=None)
+    assert settings.openai_api_key == "env-key"


### PR DESCRIPTION
## Summary
- add a `Settings` class using `pydantic-settings`
- load configuration from environment variables and `.env`
- update config helpers to return the new settings
- provide example `.env` file
- test settings behaviour
- update task list

## Testing
- `flake8 backend/app/core/settings.py backend/app/core/config.py backend/tests/unit/core/test_settings.py`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684d4569942c83318010a0c173600d77