### PR TITLE
Implement async image processor

### DIFF
--- a/.project-management/current-prd/tasks-prd-backend-hardening-epic.md
+++ b/.project-management/current-prd/tasks-prd-backend-hardening-epic.md
@@ -125,14 +125,14 @@ shiny-broccoli/
   - [x] 2.6 Configure dependency overrides in `backend/tests/conftest.py` for testing
   - [x] 2.7 Update existing unit tests to use dependency injection system
 
-- [ ] 3.0 Implement Async-Optimized Image Processing
-  - [ ] 3.1 Create `backend/services/async_image_processor.py` with `AsyncImageProcessor` class
-  - [ ] 3.2 Implement `process_image_async()` method using `asyncio.get_event_loop().run_in_executor()`
-  - [ ] 3.3 Move PIL/Pillow operations (`_ensure_png()` logic) to thread pool execution
-  - [ ] 3.4 Create `ThreadPoolExecutor` with configurable pool size for image processing
-  - [ ] 3.5 Update `OpenAIService.edit_image()` to use async image processor dependency
-  - [ ] 3.6 Maintain existing API response format while improving performance
-  - [ ] 3.7 Add performance logging to measure async optimization improvements
+- [x] 3.0 Implement Async-Optimized Image Processing
+  - [x] 3.1 Create `backend/services/async_image_processor.py` with `AsyncImageProcessor` class
+  - [x] 3.2 Implement `process_image_async()` method using `asyncio.get_event_loop().run_in_executor()`
+  - [x] 3.3 Move PIL/Pillow operations (`_ensure_png()` logic) to thread pool execution
+  - [x] 3.4 Create `ThreadPoolExecutor` with configurable pool size for image processing
+  - [x] 3.5 Update `OpenAIService.edit_image()` to use async image processor dependency
+  - [x] 3.6 Maintain existing API response format while improving performance
+  - [x] 3.7 Add performance logging to measure async optimization improvements
 
 
 - [ ] 5.0 Reorganize API Structure and Error Handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,4 @@
 2025-06-14 Marked settings import update task complete
     flake8 reported lint errors
 2025-06-14 Added dependency injection system with tests
+2025-06-14 Added async image processor and updated OpenAI service

--- a/backend/app/api/v1/endpoints/openai_integration.py
+++ b/backend/app/api/v1/endpoints/openai_integration.py
@@ -22,7 +22,11 @@ from uuid import uuid4
 
 from backend.services.openai_service import OpenAIService
 from backend.services import task_manager
-from backend.app.core.dependencies import get_openai_service
+from backend.app.core.dependencies import (
+    get_openai_service,
+    get_image_processor,
+)
+from backend.services.async_image_processor import AsyncImageProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -51,11 +55,12 @@ async def _process_request(
     mask: bytes | None,
     prompt: str,
     service: OpenAIService,
+    processor: AsyncImageProcessor,
 ) -> None:
     """Background task to send edit request to OpenAI."""
     try:
         logger.info(f"Starting OpenAI edit for request {request_id}")
-        result = await service.edit_image(image, mask, prompt)
+        result = await service.edit_image(image, mask, prompt, processor=processor)
         logger.info(f"OpenAI edit completed for request {request_id}")
         logger.info(f"OpenAI result structure: {result}")
         task_manager.set_result(request_id, result)
@@ -72,6 +77,7 @@ async def edit_image(
     mask: UploadFile | None = File(None),
     prompt: str = Form(""),
     openai_service: OpenAIService = Depends(get_openai_service),
+    image_processor: AsyncImageProcessor = Depends(get_image_processor),
 ):
     """Edit an image using OpenAI's API."""
     if image.content_type not in {"image/png", "image/jpeg", "image/jpg"}:
@@ -129,6 +135,7 @@ async def edit_image(
             mask_bytes,
             prompt,
             openai_service,
+            image_processor,
         )
     except openai.BadRequestError as exc:
         logger.warning("OpenAI bad request: %s", exc)

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -6,7 +6,7 @@ from fastapi import Depends
 
 from .config import get_settings, Settings
 from backend.services.openai_service import OpenAIService
-from backend.services.image_processor import process_image
+from backend.services.async_image_processor import AsyncImageProcessor
 
 
 def get_openai_service(settings: Settings = Depends(get_settings)) -> OpenAIService:
@@ -21,6 +21,9 @@ def get_task_repository():
     return task_manager
 
 
-def get_image_processor():
-    """Provide the default image processor implementation."""
-    return process_image
+_async_processor = AsyncImageProcessor()
+
+
+def get_image_processor() -> AsyncImageProcessor:
+    """Provide the default async image processor instance."""
+    return _async_processor

--- a/backend/services/async_image_processor.py
+++ b/backend/services/async_image_processor.py
@@ -1,0 +1,98 @@
+"""Asynchronous image processing utilities using thread pools."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
+from typing import Tuple
+
+try:  # Pillow is optional for test environments
+    from PIL import Image
+except Exception:  # pragma: no cover - optional dependency
+    Image = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncImageProcessor:
+    """Process images in a thread pool to avoid blocking the event loop."""
+
+    def __init__(self, max_workers: int = 4) -> None:
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+
+    # Internal synchronous processing function
+    def _process(
+        self, image: bytes, mask: bytes | None
+    ) -> Tuple[bytes, bytes | None, int, int]:
+        if Image is None:
+            # No processing possible without Pillow
+            return image, mask, 0, 0
+
+        png_image = self._ensure_png(image)
+        png_mask = self._ensure_png(mask) if mask else None
+
+        with Image.open(BytesIO(png_image)) as img_obj:
+            orig_w, orig_h = img_obj.size
+            supported_sizes = (256, 512, 1024)
+            target_size = 1024
+            for s in supported_sizes:
+                if max(orig_w, orig_h) <= s:
+                    target_size = s
+                    break
+            if orig_w != target_size or orig_h != target_size:
+                img_obj = img_obj.resize(
+                    (target_size, target_size), Image.Resampling.LANCZOS
+                )
+                buf = BytesIO()
+                img_obj.save(buf, format="PNG", optimize=True)
+                png_image = buf.getvalue()
+                logger.info(
+                    "Image resized from %sx%s to %sx%s",
+                    orig_w,
+                    orig_h,
+                    target_size,
+                    target_size,
+                )
+            width = height = target_size
+
+        if png_mask:
+            with Image.open(BytesIO(png_mask)) as m_obj:
+                mask_w, mask_h = m_obj.size
+                if mask_w != target_size or mask_h != target_size:
+                    m_obj = m_obj.resize(
+                        (target_size, target_size), Image.Resampling.LANCZOS
+                    )
+                    mbuf = BytesIO()
+                    m_obj.save(mbuf, format="PNG", optimize=True)
+                    png_mask = mbuf.getvalue()
+                    logger.info(
+                        "Mask resized from %sx%s to %sx%s",
+                        mask_w,
+                        mask_h,
+                        target_size,
+                        target_size,
+                    )
+        return png_image, png_mask, width, height
+
+    def _ensure_png(self, data: bytes | None) -> bytes:
+        if data is None:
+            return b""
+        if Image is None:
+            return data
+        img = Image.open(BytesIO(data))
+        buf = BytesIO()
+        img.save(buf, format="PNG", optimize=True)
+        return buf.getvalue()
+
+    async def process_image_async(
+        self, image: bytes, mask: bytes | None
+    ) -> Tuple[bytes, bytes | None, int, int]:
+        """Process image and optional mask asynchronously."""
+        loop = asyncio.get_event_loop()
+        start = asyncio.get_event_loop().time()
+        result = await loop.run_in_executor(self._executor, self._process, image, mask)
+        duration = asyncio.get_event_loop().time() - start
+        logger.info("Image processing completed in %.3f seconds", duration)
+        return result

--- a/backend/services/openai_service.py
+++ b/backend/services/openai_service.py
@@ -6,14 +6,10 @@ import logging
 from io import BytesIO
 from typing import Any
 
-try:  # Pillow is optional in test environments
-    from PIL import Image
-except Exception:
-    Image = None  # type: ignore
-
 import openai
 
 from backend.app.core.config import get_settings
+from backend.services.async_image_processor import AsyncImageProcessor
 
 logger = logging.getLogger(__name__)
 
@@ -29,17 +25,14 @@ class OpenAIService:
         self._client = openai.AsyncOpenAI(api_key=key)
         logger.debug("OpenAI client initialized")
 
-    def _ensure_png(self, data: bytes) -> bytes:
-        """Return image data encoded as optimized PNG."""
-        if Image is None:
-            return data
-        img = Image.open(BytesIO(data))
-        buf = BytesIO()
-        img.save(buf, format="PNG", optimize=True)
-        return buf.getvalue()
-
     async def edit_image(
-        self, image: bytes, mask: bytes | None, prompt: str, n: int = 1
+        self,
+        image: bytes,
+        mask: bytes | None,
+        prompt: str,
+        n: int = 1,
+        *,
+        processor: AsyncImageProcessor | None = None,
     ) -> dict[str, Any]:
         """Send an image edit request to OpenAI.
 
@@ -56,82 +49,10 @@ class OpenAIService:
         """
         logger.info("Sending image edit request")
         try:
-            png_image = self._ensure_png(image)
-            png_mask = self._ensure_png(mask) if mask else None
-
-            # Open image to get size and ensure supported dimensions
-            if Image is not None:
-                with Image.open(BytesIO(png_image)) as img_obj:
-                    orig_w, orig_h = img_obj.size
-                    # choose supported target size
-                    supported_sizes = (256, 512, 1024)
-                    target_size = 1024  # Default to largest if image is bigger
-                    for s in supported_sizes:
-                        if max(orig_w, orig_h) <= s:
-                            target_size = s
-                            break
-
-                    # Simple resize to square format for OpenAI
-                    if orig_w != target_size or orig_h != target_size:
-                        img_obj = img_obj.resize(
-                            (target_size, target_size),
-                            Image.Resampling.LANCZOS,
-                        )
-                        buf = BytesIO()
-                        img_obj.save(buf, format="PNG", optimize=True)
-                        png_image = buf.getvalue()
-
-                        logger.info(
-                            "Image resized from %sx%s to %sx%s",
-                            orig_w,
-                            orig_h,
-                            target_size,
-                            target_size,
-                        )
-
-                    width = height = target_size
-
-                # Resize mask to match if present
-                if png_mask:
-                    with Image.open(BytesIO(png_mask)) as m_obj:
-                        mask_w, mask_h = m_obj.size
-                        if mask_w != target_size or mask_h != target_size:
-                            m_obj = m_obj.resize(
-                                (target_size, target_size),
-                                Image.Resampling.LANCZOS,
-                            )
-                            mbuf = BytesIO()
-                            m_obj.save(mbuf, format="PNG", optimize=True)
-                            png_mask = mbuf.getvalue()
-
-                            logger.info(
-                                "Mask resized from %sx%s to %sx%s",
-                                mask_w,
-                                mask_h,
-                                target_size,
-                                target_size,
-                            )
-            else:
-                # This case should ideally not happen if frontend validates
-                # but as a fallback, try to get dimensions if possible
-                # This might still fail if PIL is missing and image lacks size info
-                try:
-                    # A simple way to get dimensions for PNG without full PIL
-                    # This is a placeholder and might not work for all PNGs
-                    # A more robust solution would be needed if PIL is optional
-                    if (
-                        png_image.startswith(b'\x89PNG\r\n\x1a\n')
-                        and png_image[12:16] == b'IHDR'
-                    ):
-                        import struct
-                        width, height = struct.unpack('>LL', png_image[16:24])
-                    else:  # Fallback when PNG header is missing
-                        # Proceed with original bytes if no PIL
-                        pass  # width/height may be missing; API might error
-                except Exception:
-                    # If we can't determine size and PIL is not there, we can't resize.
-                    # The API will likely reject it if not already a supported size.
-                    pass
+            processor = processor or AsyncImageProcessor()
+            png_image, png_mask, width, height = await processor.process_image_async(
+                image, mask
+            )
 
             # Prepare file-like objects for OpenAI API
             image_file = BytesIO(png_image)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,7 +3,8 @@ from fastapi.testclient import TestClient
 from typing import Generator
 
 from backend.app.main import app
-from backend.app.core.dependencies import get_openai_service
+from backend.app.core.dependencies import get_openai_service, get_image_processor
+from backend.services.async_image_processor import AsyncImageProcessor
 
 # Configure pytest-asyncio
 pytest_plugins = ("pytest_asyncio",)
@@ -30,5 +31,13 @@ def override_openai_service(monkeypatch) -> Generator[None, None, None]:
             return {"detail": "ok"}
 
     app.dependency_overrides[get_openai_service] = lambda: DummyService()
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def override_image_processor() -> Generator[None, None, None]:
+    processor = AsyncImageProcessor(max_workers=1)
+    app.dependency_overrides[get_image_processor] = lambda: processor
     yield
     app.dependency_overrides.clear()

--- a/backend/tests/integration/test_workflow.py
+++ b/backend/tests/integration/test_workflow.py
@@ -3,7 +3,6 @@ import os
 import pytest
 import httpx
 
-from backend.app.api.v1.endpoints import openai_integration
 from backend.app.core import dependencies
 from backend.app.main import app
 from fastapi.testclient import TestClient
@@ -39,9 +38,9 @@ def sample_image_bytes():
 def test_full_workflow_success(client, monkeypatch, sample_image_bytes):
     def mock_service(settings=None):
         return DummyService()
-    
+
     app.dependency_overrides[dependencies.get_openai_service] = mock_service
-    
+
     try:
         data = client.get("/")
         assert data.status_code == 200
@@ -64,12 +63,12 @@ def test_full_workflow_api_error(client, monkeypatch, sample_image_bytes):
         response=httpx.Response(400, request=httpx.Request("POST", "http://")),
         body=None,
     )
-    
+
     def mock_service(settings=None):
         return FailingService(exc)
-    
+
     app.dependency_overrides[dependencies.get_openai_service] = mock_service
-    
+
     try:
         result = client.post(
             "/api/v1/images/edit",
@@ -88,12 +87,12 @@ def test_full_workflow_connection_error(client, monkeypatch, sample_image_bytes)
     exc = openai.APIConnectionError(
         message="boom", request=httpx.Request("POST", "http://")
     )
-    
+
     def mock_service(settings=None):
         return FailingService(exc)
-    
+
     app.dependency_overrides[dependencies.get_openai_service] = mock_service
-    
+
     try:
         result = client.post(
             "/api/v1/images/edit",

--- a/backend/tests/unit/api/v1/test_openai_integration.py
+++ b/backend/tests/unit/api/v1/test_openai_integration.py
@@ -23,7 +23,7 @@ def make_error(error_cls, status_code=400):
 
 def test_edit_image(client, monkeypatch):
 
-    async def immediate(request_id, image, mask, prompt, service):
+    async def immediate(request_id, image, mask, prompt, service, processor):
         openai_integration.task_manager.set_result(request_id, {"detail": "ok"})
 
     monkeypatch.setattr(openai_integration, "_process_request", immediate)
@@ -104,7 +104,7 @@ def test_get_status(client):
     ],
 )
 def test_openai_error_mapping(client, monkeypatch, error_cls):
-    async def fail_task(request_id, image, mask, prompt, service):
+    async def fail_task(request_id, image, mask, prompt, service, processor):
         openai_integration.task_manager.set_error(request_id, "boom")
 
     monkeypatch.setattr(openai_integration, "_process_request", fail_task)

--- a/backend/tests/unit/services/test_async_image_processor.py
+++ b/backend/tests/unit/services/test_async_image_processor.py
@@ -1,0 +1,39 @@
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from backend.services.async_image_processor import AsyncImageProcessor
+
+
+@pytest.mark.asyncio
+async def test_process_image_resizes_image():
+    proc = AsyncImageProcessor(max_workers=1)
+    buf = BytesIO()
+    Image.new("RGBA", (300, 300)).save(buf, format="PNG")
+    img_bytes = buf.getvalue()
+
+    png_image, png_mask, width, height = await proc.process_image_async(img_bytes, None)
+    assert png_mask is None
+    assert (width, height) == (512, 512)
+    assert png_image.startswith(b"\x89PNG")
+
+
+@pytest.mark.asyncio
+async def test_process_image_resizes_mask():
+    proc = AsyncImageProcessor(max_workers=1)
+    img_buf = BytesIO()
+    Image.new("RGBA", (200, 200)).save(img_buf, format="PNG")
+    img_bytes = img_buf.getvalue()
+
+    mask_buf = BytesIO()
+    Image.new("L", (100, 100), color=255).save(mask_buf, format="PNG")
+    mask_bytes = mask_buf.getvalue()
+
+    png_image, png_mask, width, height = await proc.process_image_async(
+        img_bytes, mask_bytes
+    )
+    assert (width, height) == (256, 256)
+    assert png_mask is not None
+    with Image.open(BytesIO(png_mask)) as m:
+        assert m.size == (256, 256)

--- a/backend/tests/unit/services/test_openai_service.py
+++ b/backend/tests/unit/services/test_openai_service.py
@@ -136,20 +136,3 @@ async def test_edit_image_resizes_mask(monkeypatch):
     assert captured["size"] == "512x512"
     assert captured["img"] == (512, 512)
     assert captured["mask"] == (512, 512)
-
-
-def test_ensure_png_optimizes(monkeypatch):
-    def factory(api_key=None):
-        return DummyClient(api_key)
-
-    service_module = load_service(monkeypatch, factory)
-    service = service_module.OpenAIService(api_key="key")
-
-    buf = BytesIO()
-    Image.new("RGBA", (256, 256), color="red").save(buf, format="PNG", optimize=False)
-    data = buf.getvalue()
-
-    optimized = service._ensure_png(data)
-
-    assert optimized.startswith(b"\x89PNG")
-    assert len(optimized) <= len(data)


### PR DESCRIPTION
## Summary
- add `AsyncImageProcessor` for threadpooled image resizing
- integrate processor into `OpenAIService` and endpoints
- adjust dependency injection and unit tests
- generate unit tests for the new processor
- update task list and changelog

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684db7e3022483319c4f4217f1c6befa