### PR TITLE
Implement images router and update tasks

### DIFF
--- a/.project-management/current-prd/tasks-prd-backend-hardening-epic.md
+++ b/.project-management/current-prd/tasks-prd-backend-hardening-epic.md
@@ -90,6 +90,8 @@ shiny-broccoli/
 - `backend/requirements.txt` - Add structlog, redis-py dependencies
 - `backend/tests/conftest.py` - Update for new dependency injection
 - `backend/app/api/v1/endpoints/openai_integration.py` - Update to use dependency injection
+- `backend/app/core/dependencies.py` - Add process_image dependency function
+- `backend/app/api/v1/endpoints/images.py` - **Removed after relocation to routers**
 - `.flake8` - Exclude docs generator from linting
 - `backend/services/chat_storage.py` - **Removed unused chat history storage**
 - `backend/app/core/__init__.py` - **Removed empty module file**
@@ -138,7 +140,7 @@ shiny-broccoli/
 - [ ] 5.0 Reorganize API Structure and Error Handling
   - [x] 5.1 Create `backend/app/api/v1/routers/` directory structure
   - [x] 5.2 Move `health.py` endpoint to `backend/app/api/v1/routers/health.py` with router patterns
-  - [ ] 5.3 Move `images.py` endpoint to `backend/app/api/v1/routers/images.py` with dependency injection
+  - [c] 5.3 Move `images.py` endpoint to `backend/app/api/v1/routers/images.py` with dependency injection
   - [ ] 5.4 Move `openai_integration.py` functionality to `backend/app/api/v1/routers/tasks.py`
   - [ ] 5.5 Create `backend/app/core/errors.py` with RFC 7807 Problem Details models
   - [ ] 5.6 Implement global exception handler for `HTTPException` to Problem Details conversion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,4 @@
 2025-06-14 Added async image processor and updated OpenAI service
 2025-06-14 Added structlog dependency and structured logging module
 2025-06-14 Started API routers refactor with health endpoint move
+2025-06-14 Moved images endpoint to routers

--- a/backend/app/api/v1/routers/images.py
+++ b/backend/app/api/v1/routers/images.py
@@ -1,10 +1,14 @@
-"""Image upload and processing API endpoints."""
+"""Image upload and processing API endpoints using dependency injection."""
+
+from __future__ import annotations
 
 import logging
 import time
-from fastapi import APIRouter, UploadFile, File, HTTPException, status
+from typing import Awaitable, Callable
 
-from backend.services.image_processor import process_image
+from fastapi import APIRouter, UploadFile, File, HTTPException, status, Depends
+
+from backend.app.core.dependencies import get_process_image
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +24,6 @@ router = APIRouter()
 
 def _validate_file(file: UploadFile) -> None:
     """Validate uploaded file content type."""
-
     if file.content_type not in ALLOWED_TYPES:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -34,7 +37,6 @@ async def upload_image(file: UploadFile = File(...)):
     start = time.time()
     logger.info("/images/upload called")
     _validate_file(file)
-    # Stubbed processing: just acknowledge receipt
     result = {"filename": file.filename}
     logger.info("/images/upload completed in %.3f", time.time() - start)
     return result
@@ -42,7 +44,9 @@ async def upload_image(file: UploadFile = File(...)):
 
 @router.post("/images/process")
 async def process_endpoint(
-    file: UploadFile = File(...), mask: UploadFile | None = File(None)
+    file: UploadFile = File(...),
+    mask: UploadFile | None = File(None),
+    process_image: Callable[..., Awaitable[dict]] = Depends(get_process_image),
 ):
     """Process an image with an optional mask."""
     start = time.time()

--- a/backend/app/core/dependencies.py
+++ b/backend/app/core/dependencies.py
@@ -27,3 +27,10 @@ _async_processor = AsyncImageProcessor()
 def get_image_processor() -> AsyncImageProcessor:
     """Provide the default async image processor instance."""
     return _async_processor
+
+
+def get_process_image():
+    """Provide the synchronous image processing function."""
+    from backend.services.image_processor import process_image
+
+    return process_image

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from .logging import setup_logging
 
 from .core.config import get_settings
 from .api.v1.routers.health import router as health_router
-from .api.v1.endpoints.images import router as images_router
+from .api.v1.routers.images import router as images_router
 from .api.v1.endpoints.openai_integration import router as openai_router
 
 settings = get_settings()


### PR DESCRIPTION
## Summary
- migrate images endpoints to routers using dependency injection
- expose `process_image` via new dependency
- update main app import to new router
- update project tasks for progress
- record change in CHANGELOG

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684dc41f272c8331b4b51fbdddbec7e6