### PR TITLE
Implement sanitized OpenAI error handling

### DIFF
--- a/.project-management/current-prd/tasks-prd-backend-hardening-epic.md
+++ b/.project-management/current-prd/tasks-prd-backend-hardening-epic.md
@@ -138,7 +138,7 @@ shiny-broccoli/
   - [x] 3.7 Add performance logging to measure async optimization improvements
 
 
-- [ ] 5.0 Reorganize API Structure and Error Handling
+- [x] 5.0 Reorganize API Structure and Error Handling
   - [x] 5.1 Create `backend/app/api/v1/routers/` directory structure
   - [x] 5.2 Move `health.py` endpoint to `backend/app/api/v1/routers/health.py` with router patterns
   - [x] 5.3 Move `images.py` endpoint to `backend/app/api/v1/routers/images.py` with dependency injection
@@ -147,7 +147,7 @@ shiny-broccoli/
   - [x] 5.6 Implement global exception handler for `HTTPException` to Problem Details conversion
   - [x] 5.7 Update `backend/app/main.py` to use new router imports and exception handlers
   - [x] 5.8 Add validation error handling with proper Problem Details format
-  - [ ] 5.9 Replace raw OpenAI API errors with sanitized Problem Details responses
+  - [x] 5.9 Replace raw OpenAI API errors with sanitized Problem Details responses
 
 - [ ] 6.0 Implement Structured Logging and Observability
   - [x] 6.1 Add `structlog` dependency to `backend/requirements.txt`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,4 @@
 2025-06-14 Marked images router task complete
 2025-06-14 Added tasks router and RFC 7807 error handling
 2025-06-14 Added validation error handling and correlation ID logging
+2025-06-14 Sanitized OpenAI error handling

--- a/backend/app/api/v1/routers/tasks.py
+++ b/backend/app/api/v1/routers/tasks.py
@@ -27,6 +27,7 @@ from backend.app.core.dependencies import (
     get_image_processor,
 )
 from backend.services.async_image_processor import AsyncImageProcessor
+from backend.app.core.errors import from_openai_error
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +68,10 @@ async def _process_request(
         logger.info(f"Result stored for request {request_id}")
     except Exception as exc:
         logger.exception(f"OpenAI edit failed for request {request_id}: {exc}")
-        task_manager.set_error(request_id, str(exc))
+        if isinstance(exc, openai.OpenAIError):
+            task_manager.set_error(request_id, from_openai_error(exc).detail)
+        else:
+            task_manager.set_error(request_id, str(exc))
 
 
 @router.post("/images/edit")
@@ -137,45 +141,9 @@ async def edit_image(
             openai_service,
             image_processor,
         )
-    except openai.BadRequestError as exc:
-        logger.warning("OpenAI bad request: %s", exc)
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
-        )
-    except (
-        openai.AuthenticationError,
-        openai.PermissionDeniedError,
-    ) as exc:
-        logger.warning("OpenAI auth error: %s", exc)
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=str(exc),
-        )
-    except openai.RateLimitError as exc:
-        logger.warning("OpenAI rate limit: %s", exc)
-        raise HTTPException(
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail=str(exc),
-        )
-    except openai.APIConnectionError as exc:
-        logger.warning("OpenAI connection error: %s", exc)
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=str(exc),
-        )
-    except openai.APITimeoutError as exc:
-        logger.warning("OpenAI timeout: %s", exc)
-        raise HTTPException(
-            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
-            detail=str(exc),
-        )
-    except openai.APIError as exc:
-        logger.warning("OpenAI API error: %s", exc)
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
-        )
+    except openai.OpenAIError as exc:
+        logger.warning("OpenAI error: %s", exc)
+        raise from_openai_error(exc)
     except Exception as exc:
         logger.exception("OpenAI edit failed")
         raise HTTPException(

--- a/backend/app/core/errors.py
+++ b/backend/app/core/errors.py
@@ -31,3 +31,22 @@ def from_validation_error(exc: RequestValidationError) -> ProblemDetail:
     """Create a :class:`ProblemDetail` from a validation error."""
     title = HTTPStatus(422).phrase
     return ProblemDetail(title=title, detail=str(exc), status=422)
+
+
+def from_openai_error(exc) -> HTTPException:
+    """Map OpenAI errors to sanitized :class:`HTTPException` instances."""
+    import openai  # Local import to avoid hard dependency when not needed
+
+    if isinstance(exc, openai.BadRequestError):
+        return HTTPException(400, "Invalid request to OpenAI")
+    if isinstance(exc, (openai.AuthenticationError, openai.PermissionDeniedError)):
+        return HTTPException(401, "OpenAI authentication failed")
+    if isinstance(exc, openai.RateLimitError):
+        return HTTPException(429, "OpenAI rate limit exceeded")
+    if isinstance(exc, openai.APIConnectionError):
+        return HTTPException(502, "Failed to connect to OpenAI")
+    if isinstance(exc, openai.APITimeoutError):
+        return HTTPException(504, "OpenAI request timed out")
+    if isinstance(exc, openai.APIError):
+        return HTTPException(503, "OpenAI service error")
+    return HTTPException(500, "OpenAI error")

--- a/backend/tests/unit/api/v1/test_openai_integration.py
+++ b/backend/tests/unit/api/v1/test_openai_integration.py
@@ -120,3 +120,30 @@ def test_openai_error_mapping(client, monkeypatch, error_cls):
     data = status_resp.json()
     assert data["status"] == "error"
     assert data["eta_seconds"] == 0
+
+
+@pytest.mark.asyncio
+async def test_process_request_sanitizes_error():
+    class FailService:
+        async def edit_image(self, image, mask, prompt, processor=None):
+            import httpx
+            raise openai.RateLimitError(
+                "boom",
+                response=httpx.Response(429, request=httpx.Request("POST", "http://")),
+                body=None,
+            )
+
+    processor = openai_integration.AsyncImageProcessor()
+    request_id = "test1"
+    openai_integration.task_manager.create_task(request_id)
+    await openai_integration._process_request(
+        request_id,
+        b"i",
+        None,
+        "prompt",
+        FailService(),
+        processor,
+    )
+    record = openai_integration.task_manager.get_task(request_id)
+    assert record.status == "error"
+    assert record.error == "OpenAI rate limit exceeded"

--- a/backend/tests/unit/core/test_errors.py
+++ b/backend/tests/unit/core/test_errors.py
@@ -48,3 +48,18 @@ def test_validation_exception_handler():
     body = response.json()
     assert body["title"] == "Unprocessable Entity"
     assert body["status"] == 422
+
+
+def test_from_openai_error_mapping():
+    import openai
+    from backend.app.core.errors import from_openai_error
+
+    import httpx
+    error = openai.RateLimitError(
+        "boom",
+        response=httpx.Response(429, request=httpx.Request("POST", "http://")),
+        body=None,
+    )
+    http_exc = from_openai_error(error)
+    assert http_exc.status_code == 429
+    assert "rate limit" in http_exc.detail.lower()


### PR DESCRIPTION
## Summary
- sanitize OpenAI API errors via `from_openai_error`
- store sanitized messages when background image edits fail
- surface sanitized messages in the edit endpoint
- expand unit tests for error handling
- mark task 5.9 complete in task list

## Testing
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684dd42ec25883318f9dcd8eb6527e87