### PR TITLE
Update docs and tests

### DIFF
--- a/.project-management/current-prd/tasks-prd-backend-hardening-epic.md
+++ b/.project-management/current-prd/tasks-prd-backend-hardening-epic.md
@@ -101,6 +101,9 @@ shiny-broccoli/
 - `backend/app/core/__init__.py` - **Removed empty module file**
 - `backend/tests/integration/test_openai_connectivity.py` - **Removed obsolete verify_connection test**
 - `backend/tests/unit/services/test_openai_service.py` - Updated for removed verify_connection
+- `backend/tests/unit/api/v1/test_tasks.py` - Renamed unit tests for tasks router
+- `README.md` - Updated API endpoint paths
+- `.project-management/current-prd/tasks-prd-backend-hardening-epic.md` - Task progress updates
 
 ### Notes
 
@@ -168,7 +171,7 @@ shiny-broccoli/
   - [x] 7.2 Remove unused `verify_connection()` method from `OpenAIService`
   - [x] 7.3 Clean up empty `backend/app/core/__init__.py` file
   - [x] 7.4 Remove pragma: no cover statements that will never execute in production
-  - [ ] 7.5 Update import statements throughout codebase for new structure
+  - [x] 7.5 Update import statements throughout codebase for new structure
   - [ ] 7.6 Organize service layer to separate business logic from infrastructure
-  - [ ] 7.7 Update `backend/tests/` structure to match new API organization
+  - [x] 7.7 Update `backend/tests/` structure to match new API organization
   - [x] 7.8 Run linting and formatting tools to ensure code quality standards

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,4 @@
 2025-06-14 Added validation error handling and correlation ID logging
 2025-06-14 Sanitized OpenAI error handling
 2025-06-14 Added structured request logging middleware and migrated loggers to structlog
+2025-06-14 Updated README and test paths after router reorganization

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Shiny Broccoli is a full-stack web application that provides an intuitive interf
 shiny-broccoli/
 ├── backend/                    # Python FastAPI backend
 │   ├── app/
-│   │   ├── api/v1/endpoints/  # API route handlers
+│   │   ├── api/v1/routers/    # API route handlers
 │   │   ├── core/              # Configuration and settings
 │   │   └── main.py            # FastAPI application entry point
 │   ├── services/              # Business logic and external integrations
@@ -149,7 +149,8 @@ The backend provides a RESTful API with the following main endpoints:
 - `GET /` - Health check and welcome message
 - `GET /api/v1/health` - Detailed health status
 - `POST /api/v1/images/edit` - Submit image editing request
-- `POST /api/v1/openai/edit` - Direct OpenAI integration endpoint
+- `GET /api/v1/images/status/{request_id}` - Check processing status
+- `GET /api/v1/images/download/{request_id}` - Download the edited image
 
 API documentation is available at `http://localhost:8000/docs` when running the backend.
 

--- a/backend/tests/unit/api/v1/test_tasks.py
+++ b/backend/tests/unit/api/v1/test_tasks.py
@@ -1,5 +1,5 @@
 import io
-from backend.app.api.v1.routers import tasks as openai_integration
+from backend.app.api.v1.routers import tasks
 import httpx
 import openai
 import pytest
@@ -24,9 +24,9 @@ def make_error(error_cls, status_code=400):
 def test_edit_image(client, monkeypatch):
 
     async def immediate(request_id, image, mask, prompt, service, processor):
-        openai_integration.task_manager.set_result(request_id, {"detail": "ok"})
+        tasks.task_manager.set_result(request_id, {"detail": "ok"})
 
-    monkeypatch.setattr(openai_integration, "_process_request", immediate)
+    monkeypatch.setattr(tasks, "_process_request", immediate)
     file_content = io.BytesIO(b"data")
     response = client.post(
         "/api/v1/images/edit",
@@ -83,8 +83,8 @@ def test_edit_image_invalid_mask(client, monkeypatch):
 
 def test_get_status(client):
     task_id = "abc123"
-    openai_integration.task_manager.create_task(task_id)
-    openai_integration.task_manager.set_result(task_id, {"ok": True})
+    tasks.task_manager.create_task(task_id)
+    tasks.task_manager.set_result(task_id, {"ok": True})
     response = client.get(f"/api/v1/images/status/{task_id}")
     assert response.status_code == 200
     assert response.json() == {
@@ -105,9 +105,9 @@ def test_get_status(client):
 )
 def test_openai_error_mapping(client, monkeypatch, error_cls):
     async def fail_task(request_id, image, mask, prompt, service, processor):
-        openai_integration.task_manager.set_error(request_id, "boom")
+        tasks.task_manager.set_error(request_id, "boom")
 
-    monkeypatch.setattr(openai_integration, "_process_request", fail_task)
+    monkeypatch.setattr(tasks, "_process_request", fail_task)
     file_content = io.BytesIO(b"data")
     response = client.post(
         "/api/v1/images/edit",
@@ -133,10 +133,10 @@ async def test_process_request_sanitizes_error():
                 body=None,
             )
 
-    processor = openai_integration.AsyncImageProcessor()
+    processor = tasks.AsyncImageProcessor()
     request_id = "test1"
-    openai_integration.task_manager.create_task(request_id)
-    await openai_integration._process_request(
+    tasks.task_manager.create_task(request_id)
+    await tasks._process_request(
         request_id,
         b"i",
         None,
@@ -144,6 +144,6 @@ async def test_process_request_sanitizes_error():
         FailService(),
         processor,
     )
-    record = openai_integration.task_manager.get_task(request_id)
+    record = tasks.task_manager.get_task(request_id)
     assert record.status == "error"
     assert record.error == "OpenAI rate limit exceeded"


### PR DESCRIPTION
## Summary
- rename tests to match new tasks router
- update README to reflect routers and new endpoints
- mark progress in project tasks

## Testing
- `flake8`
- `npm run lint`
- `./run_tests.sh -no_integration`

------
https://chatgpt.com/codex/tasks/task_e_684ddb32e7508331bc58e86196924ef9